### PR TITLE
Fix dashboard logout loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore logs
+Rischis-Kiosk/frontend/frontend.log
+Rischis-Kiosk/kiosk-backend/backend.log

--- a/Rischis-Kiosk/frontend/dashboard.js
+++ b/Rischis-Kiosk/frontend/dashboard.js
@@ -1,6 +1,9 @@
 // dashboard.js – Admin-Zugriff und Session-Check
 
-const BACKEND_URL = "https://rischis-kiosk.onrender.com";
+// Backend-URL auf localhost setzen, damit Login und Dashboard
+// gegen denselben Server laufen. Sonst wird das Cookie nicht
+// mitgeschickt und der User wirkt sofort ausgeloggt.
+const BACKEND_URL = "http://localhost:3000";
 
 async function checkUserAndRole() {
   console.log('🟡 Dashboard: Usercheck startet');

--- a/Rischis-Kiosk/frontend/mentos.js
+++ b/Rischis-Kiosk/frontend/mentos.js
@@ -1,6 +1,8 @@
 // mentos.js – Tracker-Logik über Backend-Routen
 
-const BACKEND_URL = "https://rischis-kiosk.onrender.com";
+// Das Frontend soll mit dem gleichen Backend wie beim Login
+// kommunizieren. Daher hier ebenfalls localhost verwenden.
+const BACKEND_URL = "http://localhost:3000";
 
 async function loadUserAndSessions() {
   try {


### PR DESCRIPTION
## Summary
- ensure dashboard and mentos pages use the same backend as the login
- ignore frontend and backend log files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684338d3f2948320bacdf546c7274a8b