### PR TITLE
Fix Render start script

### DIFF
--- a/Rischis-Kiosk/kiosk-backend/package.json
+++ b/Rischis-Kiosk/kiosk-backend/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/Rischis-Kiosk/package.json
+++ b/Rischis-Kiosk/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node kiosk-backend/index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- ensure Render can start backend by adding a `start` script
- make repo-level `npm start` call the backend entry point

## Testing
- `npm start --prefix Rischis-Kiosk`
- `npm test --prefix Rischis-Kiosk/kiosk-backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684345f662448320b2652db12da620f0