### PR TITLE
Fix login fetch URLs

### DIFF
--- a/Rischis-Kiosk/frontend/admin.js
+++ b/Rischis-Kiosk/frontend/admin.js
@@ -1,6 +1,6 @@
 // admin.js – Admin-Übersicht für Produkte und Stats
 async function loadStats() {
-  const res = await fetch('http://localhost:3000/api/admin/stats', {
+  const res = await fetch('/api/admin/stats', {
     credentials: 'include',
     headers: {
       'Authorization': 'Bearer ' + getCookie('sb-access-token')

--- a/Rischis-Kiosk/frontend/dashboard.js
+++ b/Rischis-Kiosk/frontend/dashboard.js
@@ -3,7 +3,7 @@
 // Backend-URL auf localhost setzen, damit Login und Dashboard
 // gegen denselben Server laufen. Sonst wird das Cookie nicht
 // mitgeschickt und der User wirkt sofort ausgeloggt.
-const BACKEND_URL = "http://localhost:3000";
+const BACKEND_URL = "";
 
 async function checkUserAndRole() {
   console.log('🟡 Dashboard: Usercheck startet');

--- a/Rischis-Kiosk/frontend/index.html
+++ b/Rischis-Kiosk/frontend/index.html
@@ -110,7 +110,7 @@
       const email = document.getElementById('login-email').value.trim();
       const password = document.getElementById('login-password').value;
 
-      const res = await fetch('http://localhost:3000/auth/login', {
+      const res = await fetch('/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -134,7 +134,7 @@
 
       if (password !== repeat) return showMessage("Passwörter stimmen nicht überein.");
 
-      const res = await fetch('http://localhost:3000/auth/register', {
+      const res = await fetch('/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/Rischis-Kiosk/frontend/index.js
+++ b/Rischis-Kiosk/frontend/index.js
@@ -8,7 +8,7 @@ if (loginForm) {
     const email = e.target.email.value;
     const password = e.target.password.value;
 
-    const res = await fetch('http://localhost:3000/auth/login', {
+    const res = await fetch('/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -26,7 +26,7 @@ if (registerForm) {
     const email = e.target.email.value;
     const password = e.target.password.value;
 
-    const res = await fetch('http://localhost:3000/auth/register', {
+    const res = await fetch('/auth/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/Rischis-Kiosk/frontend/mentos.js
+++ b/Rischis-Kiosk/frontend/mentos.js
@@ -2,7 +2,7 @@
 
 // Das Frontend soll mit dem gleichen Backend wie beim Login
 // kommunizieren. Daher hier ebenfalls localhost verwenden.
-const BACKEND_URL = "http://localhost:3000";
+const BACKEND_URL = "";
 
 async function loadUserAndSessions() {
   try {

--- a/Rischis-Kiosk/frontend/shop.js
+++ b/Rischis-Kiosk/frontend/shop.js
@@ -2,7 +2,7 @@
 const productList = document.getElementById('product-list');
 
 async function loadProducts() {
-  const res = await fetch('http://localhost:3000/api/products', { credentials: 'include' });
+  const res = await fetch('/api/products', { credentials: 'include' });
   const products = await res.json();
 
   productList.innerHTML = '';
@@ -20,7 +20,7 @@ async function loadProducts() {
 }
 
 async function buyProduct(productId) {
-  const res = await fetch('http://localhost:3000/api/buy', {
+  const res = await fetch('/api/buy', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- make login, register and shop requests relative to the current host
- update admin, dashboard and mentos scripts to use relative paths

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6843486fdab8832087128843a23befa1