### PR TITLE
Implement feed endpoint and enhance APIs

### DIFF
--- a/Rischis-Kiosk/kiosk-backend/index.js
+++ b/Rischis-Kiosk/kiosk-backend/index.js
@@ -39,6 +39,8 @@ app.use('/api/admin', require('./routes/admin'));
 app.use('/api/admin/products', require('./routes/admin/products'));
 app.use('/api/admin/stats', require('./routes/admin/stats'));
 app.use('/api/admin/purchases', require('./routes/admin/purchases'));
+// Mentos-Fütterungen
+app.use('/feed', require('./routes/feed'));
 
 // Server starten
 const PORT = process.env.PORT || 3000;

--- a/Rischis-Kiosk/kiosk-backend/routes/feed.js
+++ b/Rischis-Kiosk/kiosk-backend/routes/feed.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const router = express.Router();
+const { createClient } = require('@supabase/supabase-js');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE
+);
+
+async function getUser(req) {
+  const token = req.cookies['sb-access-token'];
+  if (!token) return null;
+  const { data: { user }, error } = await supabase.auth.getUser(token);
+  if (error || !user) return null;
+  return user;
+}
+
+router.post('/', async (req, res) => {
+  const user = await getUser(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+
+  const { type } = req.body;
+  const { data: profile } = await supabase
+    .from('users')
+    .select('name')
+    .eq('id', user.id)
+    .single();
+
+  const name = profile?.name || user.email;
+
+  const { error } = await supabase.from('mentos_feedings').insert({
+    futterart: type,
+    gefuettert_von: name,
+    zeitstempel: new Date().toISOString()
+  });
+
+  if (error) return res.status(500).json({ error: error.message });
+  res.json({ success: true });
+});
+
+module.exports = router;

--- a/Rischis-Kiosk/kiosk-backend/routes/user.js
+++ b/Rischis-Kiosk/kiosk-backend/routes/user.js
@@ -14,10 +14,20 @@ router.get('/', async (req, res) => {
   const { data: { user }, error: authError } = await supabase.auth.getUser(token);
   if (authError || !user) return res.status(401).json({ error: 'Nicht eingeloggt' });
 
-  const { data, error } = await supabase.from('users').select('*').eq('id', user.id).single();
+  const { data, error } = await supabase
+    .from('users')
+    .select('*')
+    .eq('id', user.id)
+    .single();
   if (error || !data) return res.status(404).json({ error: 'Nutzer nicht gefunden' });
 
-  res.json(data);
+  const { data: session } = await supabase
+    .from('user_sessions')
+    .select('online')
+    .eq('user_id', user.id)
+    .single();
+
+  res.json({ ...data, online: session?.online || false });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- expose new `/feed` POST endpoint for mentos feedings
- show user online status via `user_sessions` in `/api/user`
- include all products and hide purchase price for non-admins
- mount feed route in backend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68434deb654c83208415c65fd442c5e0