### PR TITLE
Fix frontend API URLs

### DIFF
--- a/Rischis-Kiosk/frontend/dashboard.js
+++ b/Rischis-Kiosk/frontend/dashboard.js
@@ -1,6 +1,8 @@
 // dashboard.js – Admin-Zugriff und Session-Check
 
-const BACKEND_URL = "https://rischis-kiosk.onrender.com";
+// Das Backend befindet sich auf derselben Domain wie das Frontend,
+// daher reicht ein leerer Prefix für die API-Routen.
+const BACKEND_URL = "";
 
 async function checkUserAndRole() {
   try {

--- a/Rischis-Kiosk/frontend/index.js
+++ b/Rischis-Kiosk/frontend/index.js
@@ -1,6 +1,9 @@
 // index.js – Login und Registrierung via Backend statt direkter Supabase-Nutzung
 
-const BACKEND_URL = "https://rischis-kiosk.onrender.com";
+// Das Backend läuft unter derselben Domain wie das Frontend,
+// daher wird hier kein fester Host angegeben. So bleiben
+// API-Aufrufe auch bei Domainänderungen funktionsfähig.
+const BACKEND_URL = "";
 
 function showMessage(text, success = false) {
   const message = document.getElementById('message');

--- a/Rischis-Kiosk/frontend/mentos.js
+++ b/Rischis-Kiosk/frontend/mentos.js
@@ -1,8 +1,9 @@
 // mentos.js – Tracker-Logik über Backend-Routen
 
-// Das Frontend kommuniziert mit dem Backend unter
-// https://rischis-kiosk-hdoi.onrender.com
-const BACKEND_URL = "https://rischis-kiosk-hdoi.onrender.com";
+// Das Backend liegt auf derselben Domain wie dieses Frontend.
+// Daher wird kein fester Host angegeben, damit die Anwendung
+// auch nach Domainänderungen funktioniert.
+const BACKEND_URL = "";
 
 async function loadUserAndSessions() {
   try {

--- a/Rischis-Kiosk/frontend/shop.js
+++ b/Rischis-Kiosk/frontend/shop.js
@@ -1,6 +1,9 @@
 // shop.js – ersetzt Supabase-Zugriffe durch sichere API-Aufrufe an dein Backend
 
-const BACKEND_URL = "https://rischis-kiosk.onrender.com";
+// API-Aufrufe gehen an dieselbe Domain wie die Seite selbst.
+// Dadurch wird das Cookie korrekt mitgesendet, auch wenn sich
+// die Domain ändert.
+const BACKEND_URL = "";
 
 let currentUser = null;
 let userBalance = 0;


### PR DESCRIPTION
## Summary
- keep BACKEND_URL empty so requests go to the same origin

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684368ff2d5c8320a9d3636ba7427a20