### PR TITLE
Fix login cookie for cross domain

### DIFF
--- a/Rischis-Kiosk/kiosk-backend/routes/auth.js
+++ b/Rischis-Kiosk/kiosk-backend/routes/auth.js
@@ -21,7 +21,7 @@ router.post('/login', async (req, res) => {
   res.cookie('sb-access-token', data.session.access_token, {
     httpOnly: true,
     secure: true,             // über HTTPS – für lokal ggf. false setzen
-    sameSite: 'lax',
+    sameSite: 'none',         // Cookie auch bei CORS-Anfragen senden
     maxAge: 7 * 24 * 60 * 60 * 1000 // 7 Tage
   });
 
@@ -83,7 +83,7 @@ router.post('/logout', (req, res) => {
   res.clearCookie('sb-access-token', {
     httpOnly: true,
     secure: true,
-    sameSite: 'lax'
+    sameSite: 'none'
   });
 
   res.json({ message: 'Logout erfolgreich' });


### PR DESCRIPTION
## Summary
- ensure `sb-access-token` cookie is sent in cross-site requests

## Testing
- `npm test` *(fails: no tests specified)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_b_68438087a58c8320b86358756a4b1a99