### PR TITLE
Fix Mentos page loading error

### DIFF
--- a/kiosk-backend/public/mentos.html
+++ b/kiosk-backend/public/mentos.html
@@ -15,7 +15,6 @@
   </script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="activity.js"></script>
-  <script src="mentos.js" defer></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@700&display=swap" rel="stylesheet">
   <style>
     html {


### PR DESCRIPTION
## Summary
- remove outdated `mentos.js` include

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684451c681188320a98c18964b94e126