### PR TITLE
Fix shop auth and history endpoint

### DIFF
--- a/kiosk-backend/public/shop.html
+++ b/kiosk-backend/public/shop.html
@@ -15,8 +15,6 @@
   <script>
     tailwind.config = { darkMode: 'class' };
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-
   <!-- Externe Scripts -->
   <script src="activity.js"></script>
   <script src="shop.js" defer></script>
@@ -109,38 +107,5 @@
     }
   </script>
 
-  <!-- Supabase Session + /activity call -->
-  <script type="module">
-    import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
-
-    const supabase = createClient(
-      'https://izkuiqjhzeeirmcikbef.supabase.co',
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MDAwOTQsImV4cCI6MjA2NDM3NjA5NH0.mPu0jQYnt0uGoLgehNFDHZprEcmrzGJ667D31sLSbj0'
-    );
-
-    const { data: sessionData } = await supabase.auth.getSession();
-    const token = sessionData?.session?.access_token;
-
-    if (!token) {
-      alert("Du bist nicht eingeloggt.");
-      // Optional: window.location.href = "/login.html";
-    } else {
-      const user = sessionData.session.user;
-      document.getElementById('user-email').textContent = user.email;
-
-      try {
-        await fetch('/activity', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${token}`
-          },
-          body: JSON.stringify({})
-        });
-      } catch (err) {
-        console.error("Fehler beim /activity-Aufruf:", err);
-      }
-    }
-  </script>
 </body>
 </html>

--- a/kiosk-backend/public/shop.js
+++ b/kiosk-backend/public/shop.js
@@ -71,7 +71,7 @@ async function loadPurchaseHistory() {
   try {
     const sortOption = document.getElementById('sort-history')?.value || 'desc';
 
-    const res = await fetch(`${BACKEND_URL}/api/history?sort=${sortOption}`, {
+    const res = await fetch(`${BACKEND_URL}/api/purchases?sort=${sortOption}`, {
       credentials: 'include'
     });
     const history = await res.json();

--- a/kiosk-backend/routes/buy.js
+++ b/kiosk-backend/routes/buy.js
@@ -8,7 +8,11 @@ const supabase = createClient(
 );
 
 router.post('/', async (req, res) => {
-  const token = req.headers.authorization?.split('Bearer ')[1];
+  // Token bevorzugt aus dem Cookie lesen, Fallback auf Authorization-Header
+  let token = req.cookies?.['sb-access-token'];
+  if (!token) {
+    token = req.headers.authorization?.split('Bearer ')[1];
+  }
   if (!token) return res.status(401).json({ error: 'Kein Token übergeben' });
 
   const { product_id, quantity } = req.body;

--- a/kiosk-backend/utils/getUser.js
+++ b/kiosk-backend/utils/getUser.js
@@ -7,7 +7,13 @@ const supabase = createClient(
 );
 
 async function getUserFromRequest(req) {
-  const token = req.headers['authorization']?.replace('Bearer ', '');
+  // Zuerst nach einem Bearer-Token im Authorization-Header suchen
+  let token = req.headers['authorization']?.replace('Bearer ', '');
+
+  // Falls kein Header vorhanden ist, das Cookie verwenden
+  if (!token) {
+    token = req.cookies?.['sb-access-token'];
+  }
 
   if (!token) return null;
 


### PR DESCRIPTION
## Summary
- authenticate using cookie in `getUserFromRequest`
- allow `/api/buy` to read token from cookie
- load history via `/api/purchases`
- remove obsolete Supabase tracking script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68446b16b3088320a8405e4393abfc08