### PR TITLE
Remove frontend Supabase keys

### DIFF
--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -54,7 +54,7 @@ app.get('/', (req, res) => {
 });
 
 // API-Routen
-app.use('/api', feed);
+app.use('/api/feedings', feed);
 app.use('/api/products', products);
 app.use('/api', buy);
 app.use('/api/user', user);

--- a/kiosk-backend/public/index.html
+++ b/kiosk-backend/public/index.html
@@ -8,7 +8,6 @@
   <script>
     tailwind.config = { darkMode: 'class' };
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap" rel="stylesheet">
   <style>
     body {
@@ -93,11 +92,6 @@
     // Backend läuft unter derselben Domain wie das Frontend
     const BACKEND_URL = "";
 
-    const supabase = window.supabase.createClient(
-      "https://izkuiqjhzeeirmcikbef.supabase.co",
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MDAwOTQsImV4cCI6MjA2NDM3NjA5NH0.mPu0jQYnt0uGoLgehNFDHZprEcmrzGJ667D31sLSbj0"
-    );
-
     const message = document.getElementById('message');
 
     function showMessage(text, success = false) {
@@ -128,12 +122,6 @@
 
       const data = await res.json();
       if (res.ok) {
-        if (data.session) {
-          await supabase.auth.setSession({
-            access_token: data.session.access_token,
-            refresh_token: data.session.refresh_token
-          });
-        }
         showMessage("Login erfolgreich! Weiterleitung...", true);
         setTimeout(() => window.location.href = 'dashboard.html', 1000);
       } else {

--- a/kiosk-backend/public/mentos.html
+++ b/kiosk-backend/public/mentos.html
@@ -13,7 +13,6 @@
   <script>
     tailwind.config = { darkMode: 'class' };
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="activity.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@700&display=swap" rel="stylesheet">
   <style>
@@ -109,10 +108,7 @@
       document.documentElement.classList.add('dark');
     }
 
-    const supabase = window.supabase.createClient(
-      "https://izkuiqjhzeeirmcikbef.supabase.co",
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MDAwOTQsImV4cCI6MjA2NDM3NjA5NH0.mPu0jQYnt0uGoLgehNFDHZprEcmrzGJ667D31sLSbj0"
-    );
+    const BACKEND_URL = "";
 
     let countdownInterval;
 
@@ -120,26 +116,21 @@
     const resetTimerBtn = document.getElementById('reset-timer-btn');
     const clearHistoryBtn = document.getElementById('clear-history-btn');
 
-    supabase.auth.getUser().then(async ({ data }) => {
-      if (!data?.user) return;
-      setupActivityTracking(data.user.id);
-      const { data: profile } = await supabase
-        .from('users')
-        .select('role')
-        .eq('id', data.user.id)
-        .single();
-      if (profile?.role === 'admin') {
-        adminButtons.classList.remove('hidden');
-      }
-    });
+    fetch(`${BACKEND_URL}/api/user`, { credentials: 'include' })
+      .then(r => r.ok ? r.json() : null)
+      .then(user => {
+        if (user) {
+          setupActivityTracking(user.id);
+          if (user.role === 'admin') {
+            adminButtons.classList.remove('hidden');
+          }
+        }
+      });
 
     async function loadFeedings() {
-      const { data, error } = await supabase
-        .from('mentos_feedings')
-        .select('zeitstempel,futterart,gefuettert_von')
-        .order('zeitstempel', { ascending: false })
-        .limit(20);
-      if (error) return;
+      const res = await fetch(`${BACKEND_URL}/api/feedings`);
+      if (!res.ok) return;
+      const data = await res.json();
       updateTable(data);
       if (data.length) startCountdown(new Date(data[0].zeitstempel));
     }
@@ -172,9 +163,12 @@
     }
 
     async function addFeeding(type) {
-      const { data: auth } = await supabase.auth.getUser();
-      const name = auth?.user ? (auth.user.user_metadata?.name || auth.user.email.split('@')[0]) : null;
-      await supabase.from('mentos_feedings').insert({ futterart: type, gefuettert_von: name });
+      await fetch(`${BACKEND_URL}/api/feedings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ type })
+      });
       loadFeedings();
     }
 
@@ -189,10 +183,10 @@
       }
 
     async function clearFeedingHistory() {
-      await supabase
-        .from('mentos_feedings')
-        .delete()
-        .gt('zeitstempel', '1900-01-01');
+      await fetch(`${BACKEND_URL}/api/feedings`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
       resetTimerDisplay();
       loadFeedings();
     }

--- a/kiosk-backend/routes/feed.js
+++ b/kiosk-backend/routes/feed.js
@@ -10,24 +10,62 @@ async function getUser(req) {
   return user;
 }
 
+// Liste der letzten Fütterungen
+router.get('/', async (req, res) => {
+  const { data, error } = await supabase
+    .from('mentos_feedings')
+    .select('zeitstempel,futterart,gefuettert_von')
+    .order('zeitstempel', { ascending: false })
+    .limit(20);
+
+  if (error) return res.status(500).json({ error: error.message });
+  res.json(data);
+});
+
+// Neue Fütterung eintragen (optional mit Benutzer)
 router.post('/', async (req, res) => {
   const user = await getUser(req);
-  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
-
   const { type } = req.body;
-  const { data: profile } = await supabase
-    .from('users')
-    .select('name')
-    .eq('id', user.id)
-    .single();
 
-  const name = profile?.name || user.email;
+  let name = null;
+  if (user) {
+    const { data: profile } = await supabase
+      .from('users')
+      .select('name')
+      .eq('id', user.id)
+      .single();
+    name = profile?.name || user.email;
+  }
 
   const { error } = await supabase.from('mentos_feedings').insert({
     futterart: type,
     gefuettert_von: name,
     zeitstempel: new Date().toISOString()
   });
+
+  if (error) return res.status(500).json({ error: error.message });
+  res.json({ success: true });
+});
+
+// Verlauf löschen (nur Admin)
+router.delete('/', async (req, res) => {
+  const user = await getUser(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+
+  const { data: profile } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (profile?.role !== 'admin') {
+    return res.status(403).json({ error: 'Nicht erlaubt' });
+  }
+
+  const { error } = await supabase
+    .from('mentos_feedings')
+    .delete()
+    .gt('zeitstempel', '1900-01-01');
 
   if (error) return res.status(500).json({ error: error.message });
   res.json({ success: true });


### PR DESCRIPTION
## Summary
- remove Supabase library and credentials from login page
- update Mentos tracker to use backend API instead of Supabase
- expand `/api/feedings` backend route to handle list, add and delete
- register `/api/feedings` route

## Testing
- `npm test --prefix kiosk-backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68449182fadc8320ac4495a73e1a7d84