### PR TITLE
Unify BACKEND_URL definition across frontend

### DIFF
--- a/kiosk-backend/public/admin.js
+++ b/kiosk-backend/public/admin.js
@@ -1,4 +1,6 @@
-const BACKEND_URL = '';
+// Backend und Frontend laufen auf derselben Domain
+// Einheitliche Definition für alle Frontend-Skripte
+const BACKEND_URL = window.location.origin;
 
 // Aktuell eingeloggter Benutzer
 let currentUserId = null;

--- a/kiosk-backend/public/dashboard.js
+++ b/kiosk-backend/public/dashboard.js
@@ -2,7 +2,8 @@
 
 // Adresse des Backends
 // Backend und Frontend laufen auf derselben Domain
-const BACKEND_URL = "";
+// Einheitliche Definition für alle Frontend-Skripte
+const BACKEND_URL = window.location.origin;
 
 async function checkUserAndRole() {
   try {

--- a/kiosk-backend/public/index.html
+++ b/kiosk-backend/public/index.html
@@ -90,7 +90,8 @@
     }
 
     // Backend läuft unter derselben Domain wie das Frontend
-    const BACKEND_URL = "";
+    // Einheitliche Definition für alle Frontend-Skripte
+    const BACKEND_URL = window.location.origin;
 
     const message = document.getElementById('message');
 

--- a/kiosk-backend/public/index.js
+++ b/kiosk-backend/public/index.js
@@ -3,7 +3,8 @@
 // deployt ist. Alle API-Aufrufe des Frontends verwenden diese
 // Konstante, damit Frontend und Backend korrekt kommunizieren.
 // Backend und Frontend laufen auf derselben Domain
-const BACKEND_URL = "";
+// Einheitliche Definition für alle Frontend-Skripte
+const BACKEND_URL = window.location.origin;
 
 // Meldung anzeigen
 function showMessage(text, success = false) {

--- a/kiosk-backend/public/mentos.html
+++ b/kiosk-backend/public/mentos.html
@@ -108,7 +108,8 @@
       document.documentElement.classList.add('dark');
     }
 
-    const BACKEND_URL = "";
+    // Einheitliche Definition für alle Frontend-Skripte
+    const BACKEND_URL = window.location.origin;
 
     let countdownInterval;
 

--- a/kiosk-backend/public/mentos.js
+++ b/kiosk-backend/public/mentos.js
@@ -1,7 +1,8 @@
 // mentos.js – Tracker-Logik über Backend-Routen
 
 // Backend und Frontend laufen auf derselben Domain
-const BACKEND_URL = "";
+// Einheitliche Definition für alle Frontend-Skripte
+const BACKEND_URL = window.location.origin;
 
 async function loadUserAndSessions() {
   try {


### PR DESCRIPTION
## Summary
- set `window.location.origin` as `BACKEND_URL` in all frontend scripts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684493a48b848320ba2bf637a9e8ef56