### PR TITLE
Fix product sorting

### DIFF
--- a/kiosk-backend/public/shop.js
+++ b/kiosk-backend/public/shop.js
@@ -36,7 +36,8 @@ async function loadUser() {
 
 async function loadProducts() {
   try {
-    const res = await fetch(`${BACKEND_URL}/api/products`);
+    const sortOption = document.getElementById('sort-products')?.value || 'price_asc';
+    const res = await fetch(`${BACKEND_URL}/api/products?sort=${sortOption}`);
     const products = await res.json();
     const list = document.getElementById('product-list');
     list.innerHTML = '';
@@ -129,6 +130,7 @@ async function buyProduct(productId, qtyInputId, productName, unitPrice) {
 
 
 document.getElementById('sort-history')?.addEventListener('change', loadPurchaseHistory);
+document.getElementById('sort-products')?.addEventListener('change', loadProducts);
 
 document.addEventListener('DOMContentLoaded', async () => {
   await loadUser();
@@ -136,4 +138,5 @@ document.addEventListener('DOMContentLoaded', async () => {
   await loadPurchaseHistory();
 
   document.getElementById('sort-history')?.addEventListener('change', loadPurchaseHistory);
+  document.getElementById('sort-products')?.addEventListener('change', loadProducts);
 });

--- a/kiosk-backend/routes/products.js
+++ b/kiosk-backend/routes/products.js
@@ -6,7 +6,9 @@ router.get('/', async (req, res) => {
   let role = null;
   const token = req.cookies['sb-access-token'];
   if (token) {
-    const { data: { user } } = await supabase.auth.getUser(token);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser(token);
     if (user) {
       const { data: profile } = await supabase
         .from('users')
@@ -17,14 +19,25 @@ router.get('/', async (req, res) => {
     }
   }
 
-  const { data, error } = await supabase
-    .from('products')
-    .select('*')
-    .order('price', { ascending: true });
+  const sort = req.query.sort || 'price_asc';
+
+  let query = supabase.from('products').select('*');
+  if (sort === 'price_desc') {
+    query = query.order('price', { ascending: false });
+  } else if (sort === 'name_asc') {
+    query = query.order('name', { ascending: true });
+  } else if (sort === 'name_desc') {
+    query = query.order('name', { ascending: false });
+  } else {
+    // Default: price ascending
+    query = query.order('price', { ascending: true });
+  }
+
+  const { data, error } = await query;
 
   if (error) return res.status(500).json({ error: error.message });
 
-  const sanitized = data.map(p => {
+  const sanitized = data.map((p) => {
     if (role !== 'admin') delete p.purchase_price;
     return p;
   });


### PR DESCRIPTION
## Summary
- let `/api/products` sort by query string to support different options
- allow selecting product sort order in the shop frontend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6844acf239fc832089e930329cdadb8e