### PR TITLE
Fix login form layout

### DIFF
--- a/kiosk-backend/public/index.html
+++ b/kiosk-backend/public/index.html
@@ -62,10 +62,12 @@
     <form id="login-form" class="space-y-4">
       <input type="email" id="login-email" class="w-full px-3 py-2 p-3 border-2 rounded-xl border-green-400 bg-green-50 placeholder-green-700" placeholder="E-Mail" required />
       <input type="password" id="login-password" class="w-full px-3 py-2 p-3 border-2 rounded-xl border-green-400 bg-green-50 placeholder-green-700" placeholder="Passwort" required />
-      <label class="flex flex-col sm:flex-row items-center">
-        <input type="checkbox" id="remember-me" class="mr-2"> Eingeloggt bleiben
-      </label>
-      <button type="submit" class="w-full px-3 py-2 bg-green-700 text-white py-3 rounded-full shadow-lg hover:bg-green-800 hover:scale-105 transition-all duration-200 ease-in-out text-lg font-semibold">Login</button>
+      <div class="flex flex-col sm:flex-row items-center justify-between">
+        <label for="remember-me" class="flex items-center mb-2 sm:mb-0">
+          <input type="checkbox" id="remember-me" class="mr-2"> Eingeloggt bleiben
+        </label>
+        <button type="submit" class="w-full sm:w-auto px-3 py-2 bg-green-700 text-white py-3 rounded-full shadow-lg hover:bg-green-800 hover:scale-105 transition-all duration-200 ease-in-out text-lg font-semibold sm:ml-4">Login</button>
+      </div>
       <p class="text-sm text-center mt-2">Noch kein Konto? <a href="#" class="text-green-700 hover:underline" onclick="switchForm('register')">Jetzt registrieren</a></p>
     </form>
 


### PR DESCRIPTION
## Summary
- place login button next to "Eingeloggt bleiben" checkbox

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6844b0a66a648320ac20a8d70d8e8c5d