### PR TITLE
Add logout option on dashboard

### DIFF
--- a/kiosk-backend/public/dashboard.html
+++ b/kiosk-backend/public/dashboard.html
@@ -73,6 +73,11 @@
   </style>
 </head>
 <body class="flex items-center justify-center min-h-screen text-green-900 relative dark:text-white">
+  <div class="fixed top-4 right-4 z-50">
+    <button onclick="logout()" class="bg-red-600 hover:bg-red-700 text-white font-bold py-1 px-3 rounded-full shadow text-sm">
+      Logout
+    </button>
+  </div>
   <div class="fixed bottom-4 right-4 z-50">
     <button onclick="toggleDarkMode()" class="bg-gray-300/75 dark:bg-gray-700/75 text-black dark:text-white p-2 rounded-full shadow opacity-70 hover:opacity-100 transition">
       🌙

--- a/kiosk-backend/public/dashboard.js
+++ b/kiosk-backend/public/dashboard.js
@@ -46,3 +46,16 @@ if (localStorage.getItem('darkMode') !== 'false') {
 }
 
 window.addEventListener('DOMContentLoaded', checkUserAndRole);
+
+async function logout() {
+  try {
+    await fetch(`${BACKEND_URL}/api/auth/logout`, {
+      method: 'POST',
+      credentials: 'include'
+    });
+  } catch (err) {
+    console.error('Fehler beim Logout', err);
+  } finally {
+    window.location.href = 'index.html';
+  }
+}


### PR DESCRIPTION
## Summary
- add logout button on the dashboard page
- implement logout functionality in dashboard.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844b1b899e08320bcd1411eb6ca716c