### PR TITLE
Remove statistic reset feature from admin area

### DIFF
--- a/kiosk-backend/public/admin.html
+++ b/kiosk-backend/public/admin.html
@@ -165,7 +165,6 @@
       <div id="stats-container" class="mt-4 hidden">
         <div class="flex flex-col sm:flex-row justify-between items-center">
           <h2 class="text-lg sm:text-xl font-semibold mb-4">Statistik</h2>
-          <button onclick="confirmResetStats()" class="text-sm bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 focus:outline-none">Statistik zurücksetzen</button>
         </div>
         <div id="stats" class="space-y-4"></div>
       </div>

--- a/kiosk-backend/public/admin.js
+++ b/kiosk-backend/public/admin.js
@@ -154,12 +154,6 @@ async function loadStats() {
     <p class="text-sm"><strong>Gesamtsaldo aller Nutzer:</strong> <span class="${totalBalance >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}">${totalBalance.toFixed(2)} €</span></p>`;
 }
 
-async function confirmResetStats() {
-  if (!confirm('Bist du sicher, dass du alle Statistiken zurücksetzen möchtest?')) return;
-  await fetch(`${BACKEND_URL}/api/admin/stats/reset`, { method: 'POST', credentials: 'include' });
-  loadStats();
-  loadPurchases(true);
-}
 
 // ---------- Käufe ----------
 let purchasesVisible = false;

--- a/kiosk-backend/routes/admin/stats.js
+++ b/kiosk-backend/routes/admin/stats.js
@@ -24,22 +24,5 @@ router.get('/', async (req, res) => {
   });
 });
 
-router.post('/reset', async (req, res) => {
-  const { error: userError } = await supabase
-    .from('users')
-    .update({ balance: 0 })
-    .not('id', 'is', null);
-
-  const { error: purchaseError } = await supabase
-    .from('purchases')
-    .delete()
-    .not('id', 'is', null);
-
-  if (userError || purchaseError) {
-    return res.status(500).json({ error: userError?.message || purchaseError?.message });
-  }
-
-  res.status(200).json({ message: 'Statistiken zurückgesetzt' });
-});
 
 export default router;


### PR DESCRIPTION
## Summary
- delete the "Statistik zurücksetzen" button from the admin page
- drop `confirmResetStats` from `admin.js`
- remove `/reset` endpoint in the admin stats route

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6844c03fe3c0832095875d90cd4444f6