### PR TITLE
Refactor auth util usage

### DIFF
--- a/kiosk-backend/routes/buy.js
+++ b/kiosk-backend/routes/buy.js
@@ -1,22 +1,17 @@
 import express from 'express';
 import supabase from '../utils/supabase.js';
+import getUserFromRequest from '../utils/getUser.js';
 const router = express.Router();
 
 router.post('/', async (req, res) => {
-  // Token bevorzugt aus dem Cookie lesen, Fallback auf Authorization-Header
-  let token = req.cookies?.['sb-access-token'];
-  if (!token) {
-    token = req.headers.authorization?.split('Bearer ')[1];
-  }
-  if (!token) return res.status(401).json({ error: 'Kein Token übergeben' });
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
 
   const { product_id, quantity } = req.body;
   if (!product_id || !quantity || quantity <= 0) {
     return res.status(400).json({ error: 'Ungültige Eingaben' });
   }
 
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) return res.status(401).json({ error: 'Nicht eingeloggt' });
 
   const { data: dbUser } = await supabase.from('users').select('*').eq('id', user.id).single();
   const { data: product } = await supabase.from('products').select('*').eq('id', product_id).single();
@@ -26,19 +21,24 @@ router.post('/', async (req, res) => {
   const total = quantity * product.price;
   const newBalance = dbUser.balance - total;
 
-  const purchaseInsert = await supabase.from('purchases').insert({
-    user_id: dbUser.id,
-    user_name: dbUser.name,
-    product_id,
-    product_name: product.name,
-    price: total,
-    quantity
-  });
+  const [
+    { error: purchaseError },
+    { error: balanceError },
+    { error: stockError }
+  ] = await Promise.all([
+    supabase.from('purchases').insert({
+      user_id: dbUser.id,
+      user_name: dbUser.name,
+      product_id,
+      product_name: product.name,
+      price: total,
+      quantity
+    }),
+    supabase.from('users').update({ balance: newBalance }).eq('id', dbUser.id),
+    supabase.from('products').update({ stock: product.stock - quantity }).eq('id', product_id)
+  ]);
 
-  const updateBalance = await supabase.from('users').update({ balance: newBalance }).eq('id', dbUser.id);
-  const updateStock = await supabase.from('products').update({ stock: product.stock - quantity }).eq('id', product_id);
-
-  if (purchaseInsert.error || updateBalance.error || updateStock.error) {
+  if (purchaseError || balanceError || stockError) {
     return res.status(500).json({ error: 'Fehler beim Kaufvorgang' });
   }
 

--- a/kiosk-backend/routes/feed.js
+++ b/kiosk-backend/routes/feed.js
@@ -1,14 +1,7 @@
 import express from 'express';
 import supabase from '../utils/supabase.js';
+import getUserFromRequest from '../utils/getUser.js';
 const router = express.Router();
-
-async function getUser(req) {
-  const token = req.cookies['sb-access-token'];
-  if (!token) return null;
-  const { data: { user }, error } = await supabase.auth.getUser(token);
-  if (error || !user) return null;
-  return user;
-}
 
 // Liste der letzten Fütterungen
 router.get('/', async (req, res) => {
@@ -24,7 +17,7 @@ router.get('/', async (req, res) => {
 
 // Neue Fütterung eintragen (optional mit Benutzer)
 router.post('/', async (req, res) => {
-  const user = await getUser(req);
+  const user = await getUserFromRequest(req);
   const { type } = req.body;
 
   let name = null;
@@ -49,7 +42,7 @@ router.post('/', async (req, res) => {
 
 // Verlauf löschen (nur Admin)
 router.delete('/', async (req, res) => {
-  const user = await getUser(req);
+  const user = await getUserFromRequest(req);
   if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
 
   const { data: profile } = await supabase

--- a/kiosk-backend/routes/purchases.js
+++ b/kiosk-backend/routes/purchases.js
@@ -1,22 +1,20 @@
 // routes/purchases.js
 import express from 'express';
 import supabase from '../utils/supabase.js';
+import getUserFromRequest from '../utils/getUser.js';
 const router = express.Router();
 
 // GET /api/purchases?sort=desc|asc|price_asc|price_desc&limit=3
 router.get('/', async (req, res) => {
-  const token = req.cookies?.['sb-access-token'];
-  if (!token) return res.status(401).json({ error: 'Nicht eingeloggt' });
-
-  const { data: authData, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !authData?.user) return res.status(401).json({ error: 'Ungültiger Token' });
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
 
   const sort = req.query.sort || 'desc';
   const limit = parseInt(req.query.limit);
   let query = supabase
     .from('purchases')
     .select('price, quantity, created_at, product_name, product_id')
-    .eq('user_id', authData.user.id);
+    .eq('user_id', user.id);
 
   if (sort === 'asc') {
     query = query.order('created_at', { ascending: true });

--- a/kiosk-backend/routes/user.js
+++ b/kiosk-backend/routes/user.js
@@ -1,13 +1,11 @@
 import express from 'express';
 import supabase from '../utils/supabase.js';
+import getUserFromRequest from '../utils/getUser.js';
 const router = express.Router();
 
 router.get('/', async (req, res) => {
-  const token = req.cookies['sb-access-token']; // <- Cookie statt Header
-  if (!token) return res.status(401).json({ error: 'Kein Token vorhanden' });
-
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
 
   const { data, error } = await supabase
     .from('users')

--- a/kiosk-backend/utils/getUser.js
+++ b/kiosk-backend/utils/getUser.js
@@ -1,10 +1,5 @@
 // kiosk-backend/utils/getUser.js
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE
-);
+import supabase from './supabase.js';
 
 export default async function getUserFromRequest(req) {
   // Zuerst nach einem Bearer-Token im Authorization-Header suchen


### PR DESCRIPTION
## Summary
- centralize Supabase client in `getUser` util
- reuse `getUserFromRequest` in routes
- parallelize purchase transaction for efficiency
- update linting

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6844d42b27fc83208b6cf9ac72d41173