### PR TITLE
Optimize backend queries

### DIFF
--- a/kiosk-backend/routes/products.js
+++ b/kiosk-backend/routes/products.js
@@ -19,19 +19,18 @@ router.get('/', async (req, res) => {
     }
   }
 
-  const sort = req.query.sort || 'price_asc';
+  const sortOptions = {
+    price_desc: { column: 'price', asc: false },
+    price_asc: { column: 'price', asc: true },
+    name_desc: { column: 'name', asc: false },
+    name_asc: { column: 'name', asc: true },
+  };
+  const { column, asc } = sortOptions[req.query.sort] || sortOptions.price_asc;
 
-  let query = supabase.from('products').select('*');
-  if (sort === 'price_desc') {
-    query = query.order('price', { ascending: false });
-  } else if (sort === 'name_asc') {
-    query = query.order('name', { ascending: true });
-  } else if (sort === 'name_desc') {
-    query = query.order('name', { ascending: false });
-  } else {
-    // Default: price ascending
-    query = query.order('price', { ascending: true });
-  }
+  const query = supabase
+    .from('products')
+    .select('*')
+    .order(column, { ascending: asc });
 
   const { data, error } = await query;
 

--- a/kiosk-backend/routes/purchases.js
+++ b/kiosk-backend/routes/purchases.js
@@ -9,22 +9,19 @@ router.get('/', async (req, res) => {
   const user = await getUserFromRequest(req);
   if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
 
-  const sort = req.query.sort || 'desc';
+  const sortOptions = {
+    asc: { column: 'created_at', asc: true },
+    desc: { column: 'created_at', asc: false },
+    price_asc: { column: 'price', asc: true },
+    price_desc: { column: 'price', asc: false },
+  };
+  const { column, asc } = sortOptions[req.query.sort] || sortOptions.desc;
   const limit = parseInt(req.query.limit);
   let query = supabase
     .from('purchases')
     .select('price, quantity, created_at, product_name, product_id')
-    .eq('user_id', user.id);
-
-  if (sort === 'asc') {
-    query = query.order('created_at', { ascending: true });
-  } else if (sort === 'price_asc') {
-    query = query.order('price', { ascending: true });
-  } else if (sort === 'price_desc') {
-    query = query.order('price', { ascending: false });
-  } else {
-    query = query.order('created_at', { ascending: false });
-  }
+    .eq('user_id', user.id)
+    .order(column, { ascending: asc });
 
   if (Number.isInteger(limit) && limit > 0) {
     query = query.limit(limit);


### PR DESCRIPTION
## Summary
- fetch admin stats data concurrently and compute product costs faster
- use lookup table for product sorting
- simplify purchase listing sort logic

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6844d95450a08320a2a0cebf5369ff46