### PR TITLE
Improve server imports and token check

### DIFF
--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -4,9 +4,8 @@ dotenv.config();
 import express from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // Routen-Imports (nur funktionsfähige Imports!)
 import feed from './routes/feed.js';
@@ -23,7 +22,7 @@ import adminBuyForUser from './routes/admin/buy_for_user.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const publicDir = path.join(__dirname, 'public');
+const publicDir = join(__dirname, 'public');
 
 const app = express();
 const PORT = process.env.PORT || 10000;
@@ -42,11 +41,11 @@ app.use(express.static(publicDir));
 // Statische Routen
 ['admin', 'dashboard', 'mentos', 'shop'].forEach((page) => {
   app.get(`/${page}`, (req, res) => {
-    res.sendFile(path.join(publicDir, `${page}.html`));
+    res.sendFile(join(publicDir, `${page}.html`));
   });
 });
 app.get('/', (req, res) => {
-  res.sendFile(path.join(publicDir, 'index.html'));
+  res.sendFile(join(publicDir, 'index.html'));
 });
 app.get('/healthz', (req, res) => {
   res.status(200).send('OK');

--- a/kiosk-backend/utils/getUser.js
+++ b/kiosk-backend/utils/getUser.js
@@ -2,17 +2,16 @@
 import supabase from './supabase.js';
 
 export default async function getUserFromRequest(req) {
-  // Zuerst nach einem Bearer-Token im Authorization-Header suchen
-  let token = req.headers['authorization']?.replace('Bearer ', '');
-
-  // Falls kein Header vorhanden ist, das Cookie verwenden
-  if (!token) {
-    token = req.cookies?.['sb-access-token'];
-  }
+  const token =
+    req.headers.authorization?.replace('Bearer ', '') ||
+    req.cookies?.['sb-access-token'];
 
   if (!token) return null;
 
-  const { data: { user }, error } = await supabase.auth.getUser(token);
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser(token);
 
   if (error || !user) return null;
 


### PR DESCRIPTION
## Summary
- streamline Node built-in imports
- simplify user token retrieval

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6844db9f9ce0832090c629f875ebbb3c