### PR TITLE
Refactor user utilities

### DIFF
--- a/kiosk-backend/utils/getUserName.js
+++ b/kiosk-backend/utils/getUserName.js
@@ -1,0 +1,11 @@
+import supabase from './supabase.js';
+
+export default async function getUserName(userId) {
+  const { data, error } = await supabase
+    .from('users')
+    .select('name')
+    .eq('id', userId)
+    .single();
+  if (error) return null;
+  return data?.name || null;
+}

--- a/kiosk-backend/utils/getUserRole.js
+++ b/kiosk-backend/utils/getUserRole.js
@@ -1,0 +1,11 @@
+import supabase from './supabase.js';
+
+export default async function getUserRole(userId) {
+  const { data, error } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', userId)
+    .single();
+  if (error) return null;
+  return data?.role || null;
+}


### PR DESCRIPTION
## Summary
- create helper functions `getUserName` and `getUserRole`
- use new helpers in `feed.js`
- refactor `products.js` to simplify user role lookup and reuse sort options

## Testing
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_b_6844dd576e588320bebada7ae3c267c4