### PR TITLE
Preserve purchase records on product deletion

### DIFF
--- a/kiosk-backend/public/admin.js
+++ b/kiosk-backend/public/admin.js
@@ -131,7 +131,7 @@ async function toggleAvailability(id, current) {
 }
 
 async function deleteProduct(id) {
-  if (!confirm('Produkt inklusive Käufen löschen?')) return;
+  if (!confirm('Produkt löschen (Käufe bleiben erhalten)?')) return;
   await fetch(`${BACKEND_URL}/api/admin/products/${id}`, { method: 'DELETE', credentials: 'include' });
   loadProducts();
   loadStats();

--- a/kiosk-backend/routes/admin/products.js
+++ b/kiosk-backend/routes/admin/products.js
@@ -66,18 +66,8 @@ router.put('/:id/available', async (req, res) => {
 
 router.delete('/:id', async (req, res) => {
   const { id } = req.params;
-  const { error: delPurchases } = await supabase
-    .from('purchases')
-    .delete()
-    .eq('product_id', id);
-  const { error: delProduct } = await supabase
-    .from('products')
-    .delete()
-    .eq('id', id);
-  if (delPurchases || delProduct)
-    return res
-      .status(500)
-      .json({ error: delPurchases?.message || delProduct?.message });
+  const { error } = await supabase.from('products').delete().eq('id', id);
+  if (error) return res.status(500).json({ error: error.message });
   res.status(204).send();
 });
 


### PR DESCRIPTION
## Summary
- keep purchase history when deleting a product
- adjust admin UI text to reflect new behaviour

## Testing
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_b_68457091a0588320b47d0c57a97966c9