### PR TITLE
Add admin auth checks

### DIFF
--- a/kiosk-backend/routes/admin/buy_for_user.js
+++ b/kiosk-backend/routes/admin/buy_for_user.js
@@ -1,9 +1,17 @@
 import express from 'express';
 import purchaseProduct from '../../utils/purchaseProduct.js';
 import getUserAndProduct from '../../utils/getUserAndProduct.js';
+import getUserFromRequest from '../../utils/getUser.js';
+import getUserRole from '../../utils/getUserRole.js';
 const router = express.Router();
 
 router.post('/', async (req, res) => {
+  const authUser = await getUserFromRequest(req);
+  if (!authUser) return res.status(401).json({ error: 'Nicht eingeloggt' });
+
+  const role = await getUserRole(authUser.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
+
   const { user_id, product_id, quantity } = req.body;
   if (!user_id || !product_id || !quantity || quantity <= 0) {
     return res.status(400).json({ error: 'Ungültige Eingaben' });

--- a/kiosk-backend/routes/admin/products.js
+++ b/kiosk-backend/routes/admin/products.js
@@ -1,8 +1,14 @@
 import express from 'express';
 import supabase from '../../utils/supabase.js';
+import getUserFromRequest from '../../utils/getUser.js';
+import getUserRole from '../../utils/getUserRole.js';
 const router = express.Router();
 
 router.get('/', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { data, error } = await supabase
     .from('products')
     .select('id, name, price, stock, available, category');
@@ -11,6 +17,10 @@ router.get('/', async (req, res) => {
 });
 
 router.post('/', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { name, price, purchase_price, stock, category, created_by } = req.body;
 
   if (
@@ -42,6 +52,10 @@ router.post('/', async (req, res) => {
 });
 
 router.put('/:id', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { id } = req.params;
   const { name, price, stock } = req.body;
   const { error } = await supabase
@@ -54,6 +68,10 @@ router.put('/:id', async (req, res) => {
 
 // Verfügbarkeit eines Produkts umschalten
 router.put('/:id/available', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { id } = req.params;
   const { available } = req.body;
   const { error } = await supabase
@@ -65,6 +83,10 @@ router.put('/:id/available', async (req, res) => {
 });
 
 router.delete('/:id', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { id } = req.params;
   const { error } = await supabase.from('products').delete().eq('id', id);
   if (error) return res.status(500).json({ error: error.message });

--- a/kiosk-backend/routes/admin/purchases.js
+++ b/kiosk-backend/routes/admin/purchases.js
@@ -1,8 +1,14 @@
 import express from 'express';
 import supabase from '../../utils/supabase.js';
+import getUserFromRequest from '../../utils/getUser.js';
+import getUserRole from '../../utils/getUserRole.js';
 const router = express.Router();
 
 router.get('/', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { data, error } = await supabase
     .from('purchases')
     .select('user_name, product_name, price, quantity, created_at')
@@ -12,6 +18,10 @@ router.get('/', async (req, res) => {
 });
 
 router.delete('/:product_id', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { product_id } = req.params;
   const { error } = await supabase
     .from('purchases')

--- a/kiosk-backend/routes/admin/stats.js
+++ b/kiosk-backend/routes/admin/stats.js
@@ -1,8 +1,14 @@
 import express from 'express';
 import supabase from '../../utils/supabase.js';
+import getUserFromRequest from '../../utils/getUser.js';
+import getUserRole from '../../utils/getUserRole.js';
 const router = express.Router();
 
 router.get('/', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const [
     { data: users },
     { data: products },

--- a/kiosk-backend/routes/admin/users.js
+++ b/kiosk-backend/routes/admin/users.js
@@ -1,9 +1,15 @@
 import express from 'express';
 import supabase from '../../utils/supabase.js';
+import getUserFromRequest from '../../utils/getUser.js';
+import getUserRole from '../../utils/getUserRole.js';
 const router = express.Router();
 
 // Liste aller Nutzer
 router.get('/', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { data, error } = await supabase
     .from('users')
     .select('id, email, name, balance');
@@ -13,6 +19,10 @@ router.get('/', async (req, res) => {
 
 // Einzelnen Nutzer laden
 router.get('/:id', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { id } = req.params;
   const { data, error } = await supabase
     .from('users')
@@ -26,6 +36,10 @@ router.get('/:id', async (req, res) => {
 
 // Name oder Balance aktualisieren
 router.put('/:id', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { id } = req.params;
   const { name, balance } = req.body;
   const updates = {};
@@ -41,6 +55,10 @@ router.put('/:id', async (req, res) => {
 
 // Passwort ändern
 router.put('/:id/password', async (req, res) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  const role = await getUserRole(user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
   const { id } = req.params;
   const { password } = req.body;
   if (!password || password.length < 6) {


### PR DESCRIPTION
## Summary
- secure all admin routes with user and role checks
- import `getUserFromRequest` and `getUserRole` in admin routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6845896e71a0832088cbaf7811d5dccf