### PR TITLE
Fix HTML injection in frontend

### DIFF
--- a/kiosk-backend/public/admin.js
+++ b/kiosk-backend/public/admin.js
@@ -30,6 +30,15 @@ function formatDateTime(iso) {
          d.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: 'Europe/Berlin' });
 }
 
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // Eingeloggten Benutzer laden
 async function loadCurrentUser() {
   try {
@@ -56,8 +65,8 @@ async function loadProducts() {
     li.innerHTML = `
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
         <div>
-          <p class="text-base font-semibold">${p.name}</p>
-          <p class="text-sm text-gray-600 dark:text-gray-300">Preis: <strong>${p.price.toFixed(2)} €</strong> – Bestand: <strong>${p.stock}</strong> – Kategorie: <strong>${p.category || '-'}</strong></p>
+          <p class="text-base font-semibold">${escapeHtml(p.name)}</p>
+          <p class="text-sm text-gray-600 dark:text-gray-300">Preis: <strong>${p.price.toFixed(2)} €</strong> – Bestand: <strong>${p.stock}</strong> – Kategorie: <strong>${escapeHtml(p.category || '-')}</strong></p>
         </div>
         <div class="flex flex-row gap-1 sm:ml-4">
           <button onclick="toggleAvailability('${p.id}', ${p.available})" class="bg-yellow-500 text-white text-xs px-2 py-1 rounded shadow hover:bg-yellow-600 focus:outline-none">
@@ -185,7 +194,12 @@ async function loadPurchases(initial = false) {
   const res = await fetch(`${BACKEND_URL}/api/admin/purchases?offset=${purchaseOffset}&limit=${purchaseLimit}`, { credentials: 'include' });
   const data = await res.json();
   const list = document.getElementById('purchase-history');
-  const items = data.map(e => `<li>${formatDateTime(e.created_at)} – <strong>${e.user_name}</strong> kaufte <strong>${e.quantity || 1}x ${e.product_name}</strong> für ${e.price.toFixed(2)} €</li>`).join('');
+  const items = data
+    .map(
+      e =>
+        `<li>${formatDateTime(e.created_at)} – <strong>${escapeHtml(e.user_name)}</strong> kaufte <strong>${e.quantity || 1}x ${escapeHtml(e.product_name)}</strong> für ${e.price.toFixed(2)} €</li>`
+    )
+    .join('');
   if (initial) list.innerHTML = items; else list.innerHTML += items;
   purchaseOffset += purchaseLimit;
 }
@@ -248,7 +262,7 @@ async function loadUserBalances() {
   document.getElementById('balance-control-list').innerHTML = data.map(u => {
     const cls = u.balance < 0 ? 'text-red-600 dark:text-red-400 font-bold' : 'text-green-600 dark:text-green-400';
     return `<li class="flex flex-wrap items-center gap-2">
-      <span class="flex-1">${u.name}: <span class="${cls}">${u.balance.toFixed(2)} €</span></span>
+      <span class="flex-1">${escapeHtml(u.name)}: <span class="${cls}">${u.balance.toFixed(2)} €</span></span>
       <input type="number" id="bal-${u.id}" class="w-20 border px-2 py-1" step="0.01" />
       <button onclick="updateBalance('${u.id}', 'add')" class="bg-green-600 text-white px-2 py-1 rounded hover:bg-green-700">+</button>
       <button onclick="updateBalance('${u.id}', 'subtract')" class="bg-red-600 text-white px-2 py-1 rounded hover:bg-red-700">-</button>
@@ -280,7 +294,9 @@ async function loadBuyUsers() {
   const data = await res.json();
   const select = document.getElementById('buy-user');
   if (!select) return;
-  select.innerHTML = data.map(u => `<option value="${u.id}">${u.name}</option>`).join('');
+  select.innerHTML = data
+    .map(u => `<option value="${u.id}">${escapeHtml(u.name)}</option>`)
+    .join('');
 }
 
 async function loadBuyProducts() {
@@ -290,7 +306,7 @@ async function loadBuyProducts() {
   if (!select) return;
   select.innerHTML = data
     .filter(p => p.available && p.stock > 0)
-    .map(p => `<option value="${p.id}">${p.name} (${p.stock})</option>`)
+    .map(p => `<option value="${p.id}">${escapeHtml(p.name)} (${p.stock})</option>`)
     .join('');
 }
 

--- a/kiosk-backend/public/mentos.html
+++ b/kiosk-backend/public/mentos.html
@@ -116,6 +116,15 @@
     const resetTimerBtn = document.getElementById('reset-timer-btn');
     const clearHistoryBtn = document.getElementById('clear-history-btn');
 
+    function escapeHtml(str) {
+      return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     fetch(`${BACKEND_URL}/api/user`, { credentials: 'include' })
       .then(r => r.ok ? r.json() : null)
       .then(user => {
@@ -136,12 +145,16 @@
 
     function updateTable(entries) {
       const body = document.getElementById('feedings-body');
-      body.innerHTML = entries.map(e => `
+      body.innerHTML = entries
+        .map(
+          e => `
         <tr class="odd:bg-green-50 dark:odd:bg-gray-700">
           <td class="px-2 py-1 border-b">${new Date(e.zeitstempel).toLocaleString('de-DE', { timeZone: 'Europe/Berlin' })}</td>
-          <td class="px-2 py-1 border-b">${e.futterart}</td>
-          <td class="px-2 py-1 border-b">${e.gefuettert_von || ''}</td>
-        </tr>`).join('');
+          <td class="px-2 py-1 border-b">${escapeHtml(e.futterart)}</td>
+          <td class="px-2 py-1 border-b">${escapeHtml(e.gefuettert_von || '')}</td>
+        </tr>`
+        )
+        .join('');
     }
 
     function startCountdown(time) {

--- a/kiosk-backend/public/shop.js
+++ b/kiosk-backend/public/shop.js
@@ -8,6 +8,15 @@ let userBalance = 0;
 let userSortedProducts = false;
 let allProducts = [];
 
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function showMessage(text, type = 'info') {
   const el = document.getElementById('message');
   el.textContent = text;
@@ -138,7 +147,7 @@ function renderProductList(products) {
     li.innerHTML = `
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
-          <p class="text-base font-medium">${product.name}</p>
+          <p class="text-base font-medium">${escapeHtml(product.name)}</p>
           ${product.recent ? '<p class="text-xs text-yellow-600 dark:text-yellow-400">Zuletzt gekauft</p>' : ''}
           <p class="text-sm text-gray-600 dark:text-gray-300">${product.price.toFixed(2)} € – Bestand: ${product.stock}</p>
         </div>


### PR DESCRIPTION
## Summary
- sanitize dynamic values using `escapeHtml` in `admin.js`, `shop.js`, and `mentos.html`
- ensure product, user, and feeding data render as text

## Testing
- `npm test` *(fails: no test specified)*
- `node - <<'NODE'
const escapeHtml=str=>str.replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
console.log(`<p>${escapeHtml('<b>hack</b>')}</p>`);
NODE`

------
https://chatgpt.com/codex/tasks/task_b_6845903b66208320bd5a87c0ec0f79ce