### PR TITLE
Improve API error handling and validation

### DIFF
--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -19,6 +19,7 @@ import adminPurchases from './routes/admin/purchases.js';
 import adminStats from './routes/admin/stats.js';
 import adminUsers from './routes/admin/users.js';
 import adminBuyForUser from './routes/admin/buy_for_user.js';
+import errorHandler from './middleware/errorHandler.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -63,6 +64,9 @@ app.use('/api/admin/purchases', adminPurchases);
 app.use('/api/admin/stats', adminStats);
 app.use('/api/admin/users', adminUsers);
 app.use('/api/admin/buy', adminBuyForUser);
+
+// Zentrale Fehlerbehandlung
+app.use(errorHandler);
 
 // Server starten
 app.listen(PORT, () => {

--- a/kiosk-backend/middleware/errorHandler.js
+++ b/kiosk-backend/middleware/errorHandler.js
@@ -1,0 +1,9 @@
+export default function errorHandler(err, req, res, next) {
+  console.error(err);
+  if (res.headersSent) {
+    return next(err);
+  }
+  const status = err.status || 500;
+  const message = err.message || 'Serverfehler';
+  res.status(status).json({ error: message });
+}

--- a/kiosk-backend/middleware/validate.js
+++ b/kiosk-backend/middleware/validate.js
@@ -1,0 +1,42 @@
+export function validateLogin(req, res, next) {
+  const { email, password } = req.body;
+  if (typeof email !== 'string' || typeof password !== 'string') {
+    return res.status(400).json({ error: 'Ungültige Eingaben' });
+  }
+  next();
+}
+
+export function validateRegister(req, res, next) {
+  const { email, password } = req.body;
+  if (
+    typeof email !== 'string' ||
+    typeof password !== 'string' ||
+    password.length < 6
+  ) {
+    return res.status(400).json({ error: 'Ungültige Eingaben' });
+  }
+  next();
+}
+
+export function validateBuy(req, res, next) {
+  const { product_id, quantity } = req.body;
+  const pid = parseInt(product_id, 10);
+  const qty = parseInt(quantity, 10);
+  if (!pid || pid <= 0 || !qty || qty <= 0) {
+    return res.status(400).json({ error: 'Ungültige Eingaben' });
+  }
+  req.body.product_id = pid;
+  req.body.quantity = qty;
+  next();
+}
+
+export function validateAdminBuy(req, res, next) {
+  const { user_id } = req.body;
+  const uid = parseInt(user_id, 10);
+  if (!uid || uid <= 0) {
+    return res.status(400).json({ error: "Ung\u00fcltige Eingaben" });
+  }
+  req.body.user_id = uid;
+  validateBuy(req, res, next);
+}
+

--- a/kiosk-backend/routes/admin/buy_for_user.js
+++ b/kiosk-backend/routes/admin/buy_for_user.js
@@ -3,35 +3,37 @@ import purchaseProduct from '../../utils/purchaseProduct.js';
 import getUserAndProduct from '../../utils/getUserAndProduct.js';
 import getUserFromRequest from '../../utils/getUser.js';
 import getUserRole from '../../utils/getUserRole.js';
+import { validateAdminBuy } from '../../middleware/validate.js';
 const router = express.Router();
 
-router.post('/', async (req, res) => {
-  const authUser = await getUserFromRequest(req);
-  if (!authUser) return res.status(401).json({ error: 'Nicht eingeloggt' });
+router.post('/', validateAdminBuy, async (req, res, next) => {
+  try {
+    const authUser = await getUserFromRequest(req);
+    if (!authUser) return res.status(401).json({ error: 'Nicht eingeloggt' });
 
-  const role = await getUserRole(authUser.id);
-  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
+    const role = await getUserRole(authUser.id);
+    if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
 
-  const { user_id, product_id, quantity } = req.body;
-  if (!user_id || !product_id || !quantity || quantity <= 0) {
-    return res.status(400).json({ error: 'Ungültige Eingaben' });
+    const { user_id, product_id, quantity } = req.body;
+
+    const { user, product } = await getUserAndProduct(user_id, product_id);
+
+    if (!user || !product || product.stock < quantity) {
+      return res
+        .status(400)
+        .json({ error: 'Nicht gen\u00fcgend Bestand oder Nutzer nicht gefunden' });
+    }
+
+    const { error, success } = await purchaseProduct(user, product, quantity);
+
+    if (!success) {
+      return res.status(500).json({ error });
+    }
+
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
   }
-
-  const { user, product } = await getUserAndProduct(user_id, product_id);
-
-  if (!user || !product || product.stock < quantity) {
-    return res
-      .status(400)
-      .json({ error: 'Nicht genügend Bestand oder Nutzer nicht gefunden' });
-  }
-
-  const { error, success } = await purchaseProduct(user, product, quantity);
-
-  if (!success) {
-    return res.status(500).json({ error });
-  }
-
-  res.json({ success: true });
 });
 
 export default router;

--- a/kiosk-backend/routes/auth.js
+++ b/kiosk-backend/routes/auth.js
@@ -1,10 +1,11 @@
 import express from 'express';
 import supabase from '../utils/supabase.js';
 import { setAuthCookie, clearAuthCookie } from '../utils/authCookies.js';
+import { validateLogin, validateRegister } from '../middleware/validate.js';
 const router = express.Router();
 
 // 🔐 LOGIN
-router.post('/login', async (req, res) => {
+router.post('/login', validateLogin, async (req, res, next) => {
   try {
     const { email, password } = req.body;
     const { data, error } = await supabase.auth.signInWithPassword({
@@ -27,12 +28,12 @@ router.post('/login', async (req, res) => {
       },
     });
   } catch (err) {
-    res.status(500).json({ error: 'Serverfehler' });
+    next(err);
   }
 });
 
 // 🆕 LOGIN-STATUS PRÜFEN
-router.get('/me', async (req, res) => {
+router.get('/me', async (req, res, next) => {
   const token = req.cookies?.['sb-access-token'];
 
   if (!token) {
@@ -48,12 +49,12 @@ router.get('/me', async (req, res) => {
 
     res.json({ loggedIn: true, user: data.user });
   } catch (err) {
-    res.status(500).json({ loggedIn: false, error: 'Serverfehler' });
+    next(err);
   }
 });
 
 // 🧾 REGISTRIEREN
-router.post('/register', async (req, res) => {
+router.post('/register', validateRegister, async (req, res, next) => {
   try {
     const { email, password } = req.body;
     const { data, error } = await supabase.auth.signUp({ email, password });
@@ -73,7 +74,7 @@ router.post('/register', async (req, res) => {
 
     res.json({ message: 'Registrierung erfolgreich' });
   } catch (err) {
-    res.status(500).json({ error: 'Serverfehler' });
+    next(err);
   }
 });
 

--- a/kiosk-backend/routes/buy.js
+++ b/kiosk-backend/routes/buy.js
@@ -2,32 +2,34 @@ import express from 'express';
 import getUserFromRequest from '../utils/getUser.js';
 import purchaseProduct from '../utils/purchaseProduct.js';
 import getUserAndProduct from '../utils/getUserAndProduct.js';
+import { validateBuy } from '../middleware/validate.js';
 const router = express.Router();
 
-router.post('/', async (req, res) => {
-  const user = await getUserFromRequest(req);
-  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+router.post('/', validateBuy, async (req, res, next) => {
+  try {
+    const user = await getUserFromRequest(req);
+    if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
 
-  const { product_id, quantity } = req.body;
-  if (!product_id || !quantity || quantity <= 0) {
-    return res.status(400).json({ error: 'Ungültige Eingaben' });
+    const { product_id, quantity } = req.body;
+
+    const { user: dbUser, product } = await getUserAndProduct(
+      user.id,
+      product_id,
+    );
+
+    if (!product || product.stock < quantity)
+      return res.status(400).json({ error: 'Nicht gen\u00fcgend Bestand' });
+
+    const { error, success } = await purchaseProduct(dbUser, product, quantity);
+
+    if (!success) {
+      return res.status(500).json({ error });
+    }
+
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
   }
-
-  const { user: dbUser, product } = await getUserAndProduct(
-    user.id,
-    product_id,
-  );
-
-  if (!product || product.stock < quantity)
-    return res.status(400).json({ error: 'Nicht genügend Bestand' });
-
-  const { error, success } = await purchaseProduct(dbUser, product, quantity);
-
-  if (!success) {
-    return res.status(500).json({ error });
-  }
-
-  res.json({ success: true });
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- add centralized error handler middleware
- validate login, registration, and buy requests
- require user id for admin buy endpoint
- hook up middleware in routes and server

## Testing
- `cd kiosk-backend && npx --yes eslint "**/*.js"`
- `cd kiosk-backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6845a802d8408320939f641435447b59