### PR TITLE
Add Supabase setup hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Legen Sie eine `.env` Datei im Verzeichnis `kiosk-backend` an oder nutzen Sie di
 | `COOKIE_SAMESITE`       | Wert für das SameSite-Attribut            |
 | `FORCE_HTTPS`           | `true` leitet HTTP-Anfragen auf HTTPS um  |
 
+## Datenbank vorbereiten
+
+Damit Kaufvorgänge funktionieren, muss in Supabase die Funktion
+`purchase_product` vorhanden sein. Führen Sie dazu das SQL-Skript
+`kiosk-backend/sql/purchase_product.sql` in Ihrem Supabase-Projekt aus.
+
+Anschließend können Produkte im Shop gekauft werden.
+
 ## CSRF-Schutz
 
 Der Server stellt unter `/api/csrf-token` einen Endpunkt bereit, der ein

--- a/kiosk-backend/utils/purchaseProduct.js
+++ b/kiosk-backend/utils/purchaseProduct.js
@@ -13,7 +13,12 @@ export default async function purchaseProduct(user, product, quantity) {
   });
 
   if (error) {
-    const err = new Error('Fehler beim Kaufvorgang');
+    let message = 'Fehler beim Kaufvorgang';
+    if (error.message && error.message.includes('purchase_product')) {
+      message =
+        'Fehlende Funktion purchase_product – SQL unter sql/purchase_product.sql ausführen.';
+    }
+    const err = new Error(message);
     err.status = 500;
     throw err;
   }


### PR DESCRIPTION
## Summary
- advise running the `purchase_product.sql` script when setting up Supabase
- warn admins if `purchase_product` is missing

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6845ca9403908320abab8245fe484337