### PR TITLE
Fix product & user ID validation for UUIDs

### DIFF
--- a/kiosk-backend/middleware/validate.js
+++ b/kiosk-backend/middleware/validate.js
@@ -11,12 +11,12 @@ const registerSchema = z.object({
 });
 
 const buySchema = z.object({
-  product_id: z.coerce.number().int().positive(),
+  product_id: z.string().uuid(),
   quantity: z.coerce.number().int().positive(),
 });
 
 const adminBuySchema = buySchema.extend({
-  user_id: z.coerce.number().int().positive(),
+  user_id: z.string().uuid(),
 });
 
 function parse(schema, data) {


### PR DESCRIPTION
## Summary
- validate product_id and user_id as UUIDs instead of numbers

## Testing
- `npm run lint`
- `npm test` *(fails: no test specified)*
- `npm test` in root *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6845cc3e08b883209173b1697bde56e1