### PR TITLE
Add env var validation with zod

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Legen Sie eine `.env` Datei im Verzeichnis `kiosk-backend` an oder nutzen Sie di
 | `COOKIE_SAMESITE`       | Wert für das SameSite-Attribut            |
 | `FORCE_HTTPS`           | `true` leitet HTTP-Anfragen auf HTTPS um  |
 
+Beim Start des Servers werden diese Variablen mit einem Zod-Schema
+validiert. Fehlen erforderliche Werte oder sind sie ungültig, wird der
+Start abgebrochen.
+
 ## Datenbank vorbereiten
 
 Damit Kaufvorgänge funktionieren, muss in Supabase die Funktion

--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -1,5 +1,4 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import env from './utils/env.js';
 
 import express from 'express';
 import cors from 'cors';
@@ -30,7 +29,7 @@ const __dirname = dirname(__filename);
 const publicDir = join(__dirname, 'public');
 
 const app = express();
-const PORT = process.env.PORT || 10000;
+const PORT = env.PORT;
 
 // Middleware
 app.use(
@@ -42,7 +41,7 @@ app.use(
 app.use(cookieParser());
 app.use(requestLogger);
 
-if (process.env.FORCE_HTTPS === 'true') {
+if (env.FORCE_HTTPS) {
   app.set('trust proxy', 1);
   app.use((req, res, next) => {
     if (!req.secure && req.headers['x-forwarded-proto'] !== 'https') {

--- a/kiosk-backend/middleware/rateLimiter.js
+++ b/kiosk-backend/middleware/rateLimiter.js
@@ -1,12 +1,9 @@
 import rateLimit from 'express-rate-limit';
+import env from '../utils/env.js';
 
 export const loginLimiter = rateLimit({
-  windowMs: process.env.LOGIN_WINDOW_MS
-    ? parseInt(process.env.LOGIN_WINDOW_MS, 10)
-    : 15 * 60 * 1000, // 15 minutes
-  max: process.env.LOGIN_MAX_ATTEMPTS
-    ? parseInt(process.env.LOGIN_MAX_ATTEMPTS, 10)
-    : 5,
+  windowMs: env.LOGIN_WINDOW_MS,
+  max: env.LOGIN_MAX_ATTEMPTS,
   standardHeaders: true,
   legacyHeaders: false,
 });

--- a/kiosk-backend/utils/authCookies.js
+++ b/kiosk-backend/utils/authCookies.js
@@ -1,17 +1,16 @@
+import env from './env.js';
+
 export function getCookieOptions() {
   const options = {
     httpOnly: true,
-    secure:
-      process.env.COOKIE_SECURE
-        ? process.env.COOKIE_SECURE === 'true'
-        : process.env.NODE_ENV === 'production',
-    sameSite: process.env.COOKIE_SAMESITE || 'lax',
+    secure: env.COOKIE_SECURE,
+    sameSite: env.COOKIE_SAMESITE,
     path: '/',
     maxAge: 7 * 24 * 60 * 60 * 1000,
   };
 
-  if (process.env.COOKIE_DOMAIN) {
-    options.domain = process.env.COOKIE_DOMAIN;
+  if (env.COOKIE_DOMAIN) {
+    options.domain = env.COOKIE_DOMAIN;
   }
 
   return options;

--- a/kiosk-backend/utils/env.js
+++ b/kiosk-backend/utils/env.js
@@ -1,0 +1,33 @@
+import dotenv from 'dotenv';
+import { z } from 'zod';
+
+dotenv.config();
+
+const envSchema = z.object({
+  SUPABASE_URL: z.string().url(),
+  SUPABASE_SERVICE_ROLE: z.string().min(1),
+  PORT: z.coerce.number().int().positive().default(10000),
+  COOKIE_DOMAIN: z.string().optional(),
+  COOKIE_SECURE: z.enum(['true', 'false']).optional(),
+  COOKIE_SAMESITE: z.string().default('lax'),
+  FORCE_HTTPS: z.enum(['true', 'false']).optional().default('false'),
+  LOGIN_WINDOW_MS: z.coerce
+    .number()
+    .int()
+    .default(15 * 60 * 1000),
+  LOGIN_MAX_ATTEMPTS: z.coerce.number().int().default(5),
+  NODE_ENV: z.string().optional(),
+});
+
+const parsed = envSchema.parse(process.env);
+
+const env = {
+  ...parsed,
+  COOKIE_SECURE:
+    parsed.COOKIE_SECURE !== undefined
+      ? parsed.COOKIE_SECURE === 'true'
+      : parsed.NODE_ENV === 'production',
+  FORCE_HTTPS: parsed.FORCE_HTTPS === 'true',
+};
+
+export default env;

--- a/kiosk-backend/utils/supabase.js
+++ b/kiosk-backend/utils/supabase.js
@@ -1,10 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
+import env from './env.js';
 
-const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
-
-if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
-  throw new Error('Supabase credentials not set');
-}
+const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = env;
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
 


### PR DESCRIPTION
## Summary
- validate environment variables via `utils/env.js`
- use validated values in server startup and helpers
- document env validation in README

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_6845d290fba083209d13c6fe3d6f9f4b