### PR TITLE
Implement CORS whitelist for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Legen Sie eine `.env` Datei im Verzeichnis `kiosk-backend` an oder nutzen Sie di
 | `COOKIE_SECURE`         | `true` erzwingt Secure-Cookies            |
 | `COOKIE_SAMESITE`       | Wert für das SameSite-Attribut            |
 | `FORCE_HTTPS`           | `true` leitet HTTP-Anfragen auf HTTPS um  |
+| `NODE_ENV`              | Bei `production` werden nur Anfragen von `.de` Domains zugelassen |
 
 Beim Start des Servers werden diese Variablen mit einem Zod-Schema
 validiert. Fehlen erforderliche Werte oder sind sie ungültig, wird der
@@ -46,6 +47,12 @@ Anschließend können Produkte im Shop gekauft werden.
 Der Server stellt unter `/api/csrf-token` einen Endpunkt bereit, der ein
 gültiges CSRF-Token zurückliefert. Dieses muss bei schreibenden Anfragen in
 das Header-Feld `x-csrf-token` übernommen werden.
+
+## CORS-Einstellungen
+
+Im Entwicklungsmodus sind Anfragen von allen Domains erlaubt. Wird der Server
+mit `NODE_ENV=production` gestartet, akzeptiert er nur noch Ursprünge mit der
+Top-Level-Domain `.de`.
 
 ## Formatierung und Linting
 

--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -34,7 +34,25 @@ const PORT = env.PORT;
 // Middleware
 app.use(
   cors({
-    origin: true,
+    // Allow all origins in development. In production only ".de" domains are
+    // permitted. Requests without an origin header (e.g. curl) are also allowed.
+    origin: (origin, callback) => {
+      if (!origin) return callback(null, true);
+
+      if (env.NODE_ENV !== 'production') {
+        return callback(null, true);
+      }
+
+      try {
+        const { hostname } = new URL(origin);
+        if (hostname.endsWith('.de')) {
+          return callback(null, true);
+        }
+      } catch {
+        // Ignore invalid origins
+      }
+      return callback(new Error('Not allowed by CORS'));
+    },
     credentials: true,
   }),
 );


### PR DESCRIPTION
## Summary
- restrict CORS to `.de` domains when running in production
- document `NODE_ENV` environment variable
- describe the new CORS behaviour in the README

## Testing
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_b_6845d427ac8c832090524e4d2ede5c30