### PR TITLE
Improve async error handling

### DIFF
--- a/kiosk-backend/middleware/auth.js
+++ b/kiosk-backend/middleware/auth.js
@@ -1,29 +1,21 @@
 import getUserFromRequest from '../utils/getUser.js';
 import getUserRole from '../utils/getUserRole.js';
+import asyncHandler from '../utils/asyncHandler.js';
 
-export async function requireAuth(req, res, next) {
-  try {
+export const requireAuth = asyncHandler(async (req, res, next) => {
+  const user = await getUserFromRequest(req);
+  if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
+  req.user = user;
+  next();
+});
+
+export const requireAdmin = asyncHandler(async (req, res, next) => {
+  if (!req.user) {
     const user = await getUserFromRequest(req);
     if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
     req.user = user;
-    next();
-  } catch (err) {
-    next(err);
   }
-}
-
-export async function requireAdmin(req, res, next) {
-  try {
-    if (!req.user) {
-      const user = await getUserFromRequest(req);
-      if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
-      req.user = user;
-    }
-    const role = await getUserRole(req.user.id);
-    if (role !== 'admin')
-      return res.status(403).json({ error: 'Nicht erlaubt' });
-    next();
-  } catch (err) {
-    next(err);
-  }
-}
+  const role = await getUserRole(req.user.id);
+  if (role !== 'admin') return res.status(403).json({ error: 'Nicht erlaubt' });
+  next();
+});

--- a/kiosk-backend/middleware/validate.js
+++ b/kiosk-backend/middleware/validate.js
@@ -31,38 +31,18 @@ function parse(schema, data) {
   return result.data;
 }
 
-export function validateLogin(req, res, next) {
-  try {
-    req.body = parse(loginSchema, req.body);
-    next();
-  } catch (err) {
-    next(err);
-  }
+function createValidator(schema) {
+  return (req, res, next) => {
+    try {
+      req.body = parse(schema, req.body);
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
 }
 
-export function validateRegister(req, res, next) {
-  try {
-    req.body = parse(registerSchema, req.body);
-    next();
-  } catch (err) {
-    next(err);
-  }
-}
-
-export function validateBuy(req, res, next) {
-  try {
-    req.body = parse(buySchema, req.body);
-    next();
-  } catch (err) {
-    next(err);
-  }
-}
-
-export function validateAdminBuy(req, res, next) {
-  try {
-    req.body = parse(adminBuySchema, req.body);
-    next();
-  } catch (err) {
-    next(err);
-  }
-}
+export const validateLogin = createValidator(loginSchema);
+export const validateRegister = createValidator(registerSchema);
+export const validateBuy = createValidator(buySchema);
+export const validateAdminBuy = createValidator(adminBuySchema);

--- a/kiosk-backend/routes/admin/buy_for_user.js
+++ b/kiosk-backend/routes/admin/buy_for_user.js
@@ -3,10 +3,14 @@ import purchaseProduct from '../../utils/purchaseProduct.js';
 import getUserAndProduct from '../../utils/getUserAndProduct.js';
 import { requireAdmin } from '../../middleware/auth.js';
 import { validateAdminBuy } from '../../middleware/validate.js';
+import asyncHandler from '../../utils/asyncHandler.js';
 const router = express.Router();
 
-router.post('/', validateAdminBuy, requireAdmin, async (req, res, next) => {
-  try {
+router.post(
+  '/',
+  validateAdminBuy,
+  requireAdmin,
+  asyncHandler(async (req, res) => {
     const authUser = req.user;
 
     const { user_id, product_id, quantity } = req.body;
@@ -23,9 +27,7 @@ router.post('/', validateAdminBuy, requireAdmin, async (req, res, next) => {
 
     const result = await purchaseProduct(user, product, quantity);
     res.json(result);
-  } catch (err) {
-    next(err);
-  }
-});
+  }),
+);
 
 export default router;

--- a/kiosk-backend/routes/auth.js
+++ b/kiosk-backend/routes/auth.js
@@ -3,11 +3,15 @@ import supabase from '../utils/supabase.js';
 import { setAuthCookie, clearAuthCookie } from '../utils/authCookies.js';
 import { validateLogin, validateRegister } from '../middleware/validate.js';
 import { loginLimiter } from '../middleware/rateLimiter.js';
+import asyncHandler from '../utils/asyncHandler.js';
 const router = express.Router();
 
 // 🔐 LOGIN
-router.post('/login', loginLimiter, validateLogin, async (req, res, next) => {
-  try {
+router.post(
+  '/login',
+  loginLimiter,
+  validateLogin,
+  asyncHandler(async (req, res) => {
     const { email, password } = req.body;
     const { data, error } = await supabase.auth.signInWithPassword({
       email,
@@ -28,20 +32,19 @@ router.post('/login', loginLimiter, validateLogin, async (req, res, next) => {
         refresh_token: data.session.refresh_token,
       },
     });
-  } catch (err) {
-    next(err);
-  }
-});
+  }),
+);
 
 // 🆕 LOGIN-STATUS PRÜFEN
-router.get('/me', async (req, res, next) => {
-  const token = req.cookies?.['sb-access-token'];
+router.get(
+  '/me',
+  asyncHandler(async (req, res) => {
+    const token = req.cookies?.['sb-access-token'];
 
-  if (!token) {
-    return res.status(401).json({ loggedIn: false });
-  }
+    if (!token) {
+      return res.status(401).json({ loggedIn: false });
+    }
 
-  try {
     const { data, error } = await supabase.auth.getUser(token);
 
     if (error || !data?.user) {
@@ -49,14 +52,14 @@ router.get('/me', async (req, res, next) => {
     }
 
     res.json({ loggedIn: true, user: data.user });
-  } catch (err) {
-    next(err);
-  }
-});
+  }),
+);
 
 // 🧾 REGISTRIEREN
-router.post('/register', validateRegister, async (req, res, next) => {
-  try {
+router.post(
+  '/register',
+  validateRegister,
+  asyncHandler(async (req, res) => {
     const { email, password } = req.body;
     const { data, error } = await supabase.auth.signUp({ email, password });
 
@@ -74,10 +77,8 @@ router.post('/register', validateRegister, async (req, res, next) => {
     });
 
     res.json({ message: 'Registrierung erfolgreich' });
-  } catch (err) {
-    next(err);
-  }
-});
+  }),
+);
 
 // 🧼 LOGOUT
 router.post('/logout', (req, res) => {

--- a/kiosk-backend/routes/buy.js
+++ b/kiosk-backend/routes/buy.js
@@ -2,17 +2,19 @@ import express from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import { buyProduct } from '../services/purchaseService.js';
 import { validateBuy } from '../middleware/validate.js';
+import asyncHandler from '../utils/asyncHandler.js';
 const router = express.Router();
 
-router.post('/', validateBuy, requireAuth, async (req, res, next) => {
-  try {
+router.post(
+  '/',
+  validateBuy,
+  requireAuth,
+  asyncHandler(async (req, res) => {
     const user = req.user;
     const { product_id, quantity } = req.body;
     const result = await buyProduct(user.id, product_id, quantity);
     res.json(result);
-  } catch (err) {
-    next(err);
-  }
-});
+  }),
+);
 
 export default router;

--- a/kiosk-backend/utils/asyncHandler.js
+++ b/kiosk-backend/utils/asyncHandler.js
@@ -1,0 +1,5 @@
+export default function asyncHandler(fn) {
+  return function wrapped(req, res, next) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}


### PR DESCRIPTION
## Summary
- create a helper `asyncHandler`
- refactor auth and buy routes to use the helper
- refactor admin buy and auth middleware to use the helper
- simplify validation middleware with `createValidator`

## Testing
- `npm run lint --prefix kiosk-backend`


------
https://chatgpt.com/codex/tasks/task_b_6845d58743ec8320a40fc99ca5406ebd