### PR TITLE
Add Helmet middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Im Entwicklungsmodus sind Anfragen von allen Domains erlaubt. Wird der Server
 mit `NODE_ENV=production` gestartet, akzeptiert er nur noch Ursprünge mit der
 Top-Level-Domain `.de`.
 
+## Sicherheits-Header
+
+Über das Paket [Helmet](https://www.npmjs.com/package/helmet) werden
+Standard-HTTP-Sicherheits-Header wie `X-Frame-Options` oder
+`Content-Security-Policy` gesetzt. Dadurch verringern sich typische
+Angriffsflächen wie Clickjacking.
+
 ## Formatierung und Linting
 
 Das Projekt verwendet ESLint und Prettier zur Code-Qualität. Die folgenden Befehle stehen zur Verfügung:

--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -4,6 +4,7 @@ import express from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import csrf from 'csurf';
+import helmet from 'helmet';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -33,6 +34,7 @@ const app = express();
 const PORT = env.PORT;
 
 // Middleware
+app.use(helmet());
 app.use(
   cors({
     // Allow all origins in development. In production only ".de" domains are

--- a/kiosk-backend/package-lock.json
+++ b/kiosk-backend/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-rate-limit": "^6.11.2",
+        "helmet": "^8.1.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
         "zod": "^3.25.56"
@@ -1348,6 +1349,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/help-me": {

--- a/kiosk-backend/package.json
+++ b/kiosk-backend/package.json
@@ -21,6 +21,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-rate-limit": "^6.11.2",
+    "helmet": "^8.1.0",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",
     "zod": "^3.25.56"


### PR DESCRIPTION
## Summary
- add helmet to package.json
- mount helmet to send standard security headers
- document security headers via Helmet in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6845dac570bc83208d69e88113a5a573