### PR TITLE
Fix content security policy for Tailwind CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Standard-HTTP-Sicherheits-Header wie `X-Frame-Options` oder
 `Content-Security-Policy` gesetzt. Dadurch verringern sich typische
 Angriffsflächen wie Clickjacking.
 
+Da das Frontend Tailwind CSS über ein CDN lädt, ist `cdn.tailwindcss.com`
+im `script-src`-Directive der Content-Security-Policy erlaubt. Diese
+Konfiguration befindet sich in `kiosk-backend/index.js`.
+
 ## Formatierung und Linting
 
 Das Projekt verwendet ESLint und Prettier zur Code-Qualität. Die folgenden Befehle stehen zur Verfügung:

--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -34,7 +34,16 @@ const app = express();
 const PORT = env.PORT;
 
 // Middleware
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        ...helmet.contentSecurityPolicy.getDefaultDirectives(),
+        'script-src': ["'self'", 'https://cdn.tailwindcss.com'],
+      },
+    },
+  }),
+);
 app.use(
   cors({
     // Allow all origins in development. In production only ".de" domains are


### PR DESCRIPTION
## Summary
- allow Tailwind CDN in Helmet CSP
- document why the CSP configuration is needed

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6845e1c52f748320909104419cae7e70