### PR TITLE
Fix fonts in content security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Standard-HTTP-Sicherheits-Header wie `X-Frame-Options` oder
 `Content-Security-Policy` gesetzt. Dadurch verringern sich typische
 Angriffsflächen wie Clickjacking.
 
+Das Frontend lädt Tailwind CSS sowie Google Fonts aus externen Quellen.
+Darum erlaubt die Content-Security-Policy in `kiosk-backend/index.js`
+neben `cdn.tailwindcss.com` auch die Domains `fonts.googleapis.com` und
+`fonts.gstatic.com`. Zudem wird für Inline-Styles `'unsafe-inline'`
+freigegeben, damit das Tailwind-CDN seine Styles einfügen kann.
+
 ## Formatierung und Linting
 
 Das Projekt verwendet ESLint und Prettier zur Code-Qualität. Die folgenden Befehle stehen zur Verfügung:

--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -34,7 +34,22 @@ const app = express();
 const PORT = env.PORT;
 
 // Middleware
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        ...helmet.contentSecurityPolicy.getDefaultDirectives(),
+        'script-src': ["'self'", 'https://cdn.tailwindcss.com'],
+        'style-src': [
+          "'self'",
+          'https://fonts.googleapis.com',
+          "'unsafe-inline'",
+        ],
+        'font-src': ["'self'", 'https://fonts.gstatic.com'],
+      },
+    },
+  }),
+);
 app.use(
   cors({
     // Allow all origins in development. In production only ".de" domains are


### PR DESCRIPTION
## Summary
- allow Google Fonts in Helmet CSP
- mention fonts and CSP details in README

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6845e1c52f748320909104419cae7e70