### PR TITLE
Serve favicon as .ico

### DIFF
--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -90,6 +90,9 @@ app.use(express.static(publicDir));
 app.get('/', (req, res) => {
   res.sendFile(join(publicDir, 'index.html'));
 });
+app.get('/favicon.ico', (req, res) => {
+  res.sendFile(join(publicDir, 'favicon.jpeg'));
+});
 app.get('/healthz', (req, res) => {
   res.status(200).send('OK');
 });

--- a/kiosk-backend/public/admin.html
+++ b/kiosk-backend/public/admin.html
@@ -16,6 +16,7 @@
   <!-- JavaScript-Logik -->
   <script src="admin.js" defer></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico" type="image/jpeg">
   <style>
   html { 
     scroll-behavior: smooth; 

--- a/kiosk-backend/public/dashboard.html
+++ b/kiosk-backend/public/dashboard.html
@@ -16,6 +16,7 @@
   <script src="dashboard.js" defer></script>
 
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico" type="image/jpeg">
   <style>
     html {
       scroll-behavior: smooth;

--- a/kiosk-backend/public/index.html
+++ b/kiosk-backend/public/index.html
@@ -9,6 +9,7 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico" type="image/jpeg">
   <style>
     body {
       font-family: 'Inter', sans-serif;

--- a/kiosk-backend/public/mentos.html
+++ b/kiosk-backend/public/mentos.html
@@ -14,6 +14,7 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@700&display=swap" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico" type="image/jpeg">
   <style>
     html {
       scroll-behavior: smooth;

--- a/kiosk-backend/public/shop.html
+++ b/kiosk-backend/public/shop.html
@@ -20,6 +20,7 @@
 
   <!-- Fonts und Styles -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap" rel="stylesheet" />
+  <link rel="icon" href="/favicon.ico" type="image/jpeg">
   <style>
     html {
       scroll-behavior: smooth;


### PR DESCRIPTION
## Summary
- add `/favicon.ico` route
- reference the ICO path from HTML pages

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6845e643a4008320b6641287b5ece11c