### PR TITLE
Add buzzer page skeleton

### DIFF
--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -82,7 +82,7 @@ app.use(express.json());
 app.use(express.static(publicDir));
 
 // Statische Routen
-['admin', 'dashboard', 'mentos', 'shop'].forEach((page) => {
+['admin', 'dashboard', 'mentos', 'shop', 'buzzer'].forEach((page) => {
   app.get(`/${page}`, (req, res) => {
     res.sendFile(join(publicDir, `${page}.html`));
   });

--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
+    <meta name="apple-mobile-web-app-title" content="Rischis Kiosk" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="theme-color" content="#0f172a" />
+    <title>Buzzer – Rischis Kiosk</title>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = { darkMode: 'class' };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="buzzer.js" defer></script>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" href="/favicon.jpeg" type="image/jpeg" />
+    <style>
+      html {
+        scroll-behavior: smooth;
+        background: linear-gradient(135deg, #d1fae5, #a7f3d0, #6ee7b7);
+      }
+      html.dark {
+        background: linear-gradient(135deg, #0f172a, #1e293b, #334155);
+        color-scheme: dark;
+      }
+      body {
+        font-family: 'Inter', sans-serif;
+        max-width: 100vw;
+        overflow-x: hidden;
+        -webkit-overflow-scrolling: touch;
+        padding: env(safe-area-inset-top) env(safe-area-inset-right)
+          env(safe-area-inset-bottom) env(safe-area-inset-left);
+      }
+      h1,
+      h2 {
+        font-family: 'Poppins', sans-serif;
+      }
+    </style>
+  </head>
+  <body class="text-green-900 dark:text-white">
+    <div class="fixed bottom-4 right-4 z-50">
+      <button
+        onclick="toggleDarkMode()"
+        class="bg-gray-300/75 dark:bg-gray-700/75 text-black dark:text-white p-2 rounded-full shadow opacity-70 hover:opacity-100 transition"
+      >
+        🌙
+      </button>
+    </div>
+
+    <div class="max-w-screen-md mx-auto mt-8 p-4 space-y-6">
+      <h1 class="text-3xl font-bold text-center">Buzzer</h1>
+
+      <section
+        id="round-section"
+        class="p-4 border rounded-lg dark:border-gray-600"
+      >
+        <h2 class="text-xl font-semibold mb-2">Aktive Runde</h2>
+        <div id="round-info" class="text-sm text-gray-700 dark:text-gray-300">
+          Lade...
+        </div>
+        <button
+          id="join-btn"
+          class="mt-3 px-3 py-1 bg-green-600 text-white rounded hidden"
+        >
+          Beitreten
+        </button>
+      </section>
+
+      <section
+        id="kolo-section"
+        class="p-4 border rounded-lg dark:border-gray-600"
+      >
+        <h2 class="text-xl font-semibold mb-2">KOLO</h2>
+        <div id="kolo-info" class="text-sm text-gray-700 dark:text-gray-300">
+          Warte auf neues KOLO…
+        </div>
+        <div class="flex gap-2 mt-3">
+          <button
+            id="buzz-btn"
+            class="px-3 py-1 bg-blue-600 text-white rounded disabled:opacity-50"
+          >
+            Buzz
+          </button>
+          <button
+            id="skip-btn"
+            class="px-3 py-1 bg-gray-500 text-white rounded disabled:opacity-50"
+          >
+            Skip
+          </button>
+        </div>
+      </section>
+
+      <section
+        id="admin-section"
+        class="hidden p-4 border rounded-lg dark:border-gray-600"
+      >
+        <h2 class="text-xl font-semibold mb-2">Admin-Funktionen</h2>
+        <div id="admin-controls" class="space-y-2"></div>
+      </section>
+
+      <section
+        id="general-section"
+        class="p-4 border rounded-lg dark:border-gray-600"
+      >
+        <h2 class="text-xl font-semibold mb-2">Allgemeines</h2>
+        <div
+          id="general-info"
+          class="space-y-1 text-sm text-gray-700 dark:text-gray-300"
+        ></div>
+      </section>
+
+      <p id="error" class="text-red-600 hidden"></p>
+    </div>
+  </body>
+</html>

--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -1,0 +1,74 @@
+// buzzer.js – einfache Steuerung der Buzzer-Seite
+
+const SUPABASE_URL = 'SUPABASE_URL'; // TODO: anpassen
+const SUPABASE_ANON_KEY = 'SUPABASE_ANON_KEY'; // TODO: anpassen
+
+const BACKEND_URL = window.location.origin;
+const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+function toggleDarkMode() {
+  const isDark = document.documentElement.classList.toggle('dark');
+  localStorage.setItem('darkMode', isDark ? 'true' : 'false');
+}
+if (localStorage.getItem('darkMode') !== 'false') {
+  document.documentElement.classList.add('dark');
+}
+
+async function checkUser() {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/user`, {
+      credentials: 'include',
+    });
+    if (!res.ok) throw new Error('not auth');
+    const user = await res.json();
+    return user;
+  } catch (err) {
+    window.location.href = 'index.html';
+    return null;
+  }
+}
+
+async function loadRound() {
+  const { data: round } = await supabase
+    .from('buzzer_rounds')
+    .select('*')
+    .eq('active', true)
+    .single();
+
+  const infoEl = document.getElementById('round-info');
+  const joinBtn = document.getElementById('join-btn');
+
+  if (round) {
+    infoEl.textContent = `Einsatz: ${round.bet} Punkte, Limit: ${round.points_limit}`;
+    joinBtn.classList.remove('hidden');
+  } else {
+    infoEl.textContent = 'Keine laufende Runde';
+    joinBtn.classList.add('hidden');
+  }
+}
+
+async function loadGeneralInfo() {
+  const { data: online } = await supabase
+    .from('user_sessions')
+    .select('username, online, users(role)');
+  const container = document.getElementById('general-info');
+  container.innerHTML = '';
+  online?.forEach((u) => {
+    const li = document.createElement('div');
+    const color = u.users?.role === 'admin' ? 'text-red-600' : 'text-green-600';
+    li.innerHTML = `<span class="${color}">${u.username}</span> – ${u.online ? 'online' : 'offline'}`;
+    container.appendChild(li);
+  });
+}
+
+async function init() {
+  const user = await checkUser();
+  if (!user) return;
+  if (user.role === 'admin') {
+    document.getElementById('admin-section').classList.remove('hidden');
+  }
+  await loadRound();
+  await loadGeneralInfo();
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- add new route entry for `buzzer`
- create `buzzer.html` with basic layout and Tailwind styling
- add client script `buzzer.js` to fetch user info and read Supabase tables

## Testing
- `npm run lint`
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_b_6845ecaee63883209c3a98fa72e9ef78