### PR TITLE
Implement multiplayer buzzer endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Eine kleine Express-Anwendung zur Verwaltung eines digitalen Kiosks. Die Anwendung nutzt Supabase als Datenbank.
 
+Zusätzlich enthält das Repository ein Multiplayer-Buzzer-Spiel, das ebenfalls Supabase zur Echtzeit-Synchronisation verwendet. Der Server stellt hierfür unter `/api/buzzer` diverse Endpunkte bereit.
+
 ## Installation
 
 ```bash
@@ -19,15 +21,15 @@ npm start
 
 Legen Sie eine `.env` Datei im Verzeichnis `kiosk-backend` an oder nutzen Sie die bereitgestellte `.env.example` als Vorlage.
 
-| Variable                | Beschreibung                              |
-|-------------------------|-------------------------------------------|
-| `SUPABASE_URL`          | URL Ihres Supabase Projekts               |
-| `SUPABASE_SERVICE_ROLE` | Service Role Key von Supabase             |
-| `PORT`                  | Port, auf dem der Server läuft (optional) |
-| `COOKIE_DOMAIN`         | Domain für Cookies (optional)             |
-| `COOKIE_SECURE`         | `true` erzwingt Secure-Cookies            |
-| `COOKIE_SAMESITE`       | Wert für das SameSite-Attribut            |
-| `FORCE_HTTPS`           | `true` leitet HTTP-Anfragen auf HTTPS um  |
+| Variable                | Beschreibung                                                      |
+| ----------------------- | ----------------------------------------------------------------- |
+| `SUPABASE_URL`          | URL Ihres Supabase Projekts                                       |
+| `SUPABASE_SERVICE_ROLE` | Service Role Key von Supabase                                     |
+| `PORT`                  | Port, auf dem der Server läuft (optional)                         |
+| `COOKIE_DOMAIN`         | Domain für Cookies (optional)                                     |
+| `COOKIE_SECURE`         | `true` erzwingt Secure-Cookies                                    |
+| `COOKIE_SAMESITE`       | Wert für das SameSite-Attribut                                    |
+| `FORCE_HTTPS`           | `true` leitet HTTP-Anfragen auf HTTPS um                          |
 | `NODE_ENV`              | Bei `production` werden nur Anfragen von `.de` Domains zugelassen |
 
 Beim Start des Servers werden diese Variablen mit einem Zod-Schema
@@ -62,3 +64,22 @@ Das Projekt verwendet ESLint und Prettier zur Code-Qualität. Die folgenden Befe
 npm run lint     # Code mit ESLint prüfen
 npm run format   # Code mit Prettier formatieren
 ```
+
+## Buzzer-Spiel
+
+Das Buzzer-Spiel ermöglicht schnelle Musikquiz-Runden. Es nutzt Supabase für Authentifizierung, Datenbankzugriffe und Realtime-Channels.
+
+### Features
+
+- **Rundenverwaltung** durch einen Admin
+- **Echtzeit-Buzzern** und Skippen – nur der erste Buzz zählt
+- Punktevergabe manuell durch den Admin
+- Verteilung des Einsatzes: 95 % an Gewinner, 5 % an Bank
+
+### API-Endpunkte (Auszug)
+
+- `GET /api/buzzer/round` – aktive Runde abrufen
+- `POST /api/buzzer/round` – neue Runde starten (Admin)
+- `POST /api/buzzer/join` – aktueller Runde beitreten
+- `POST /api/buzzer/buzz` – im laufenden KOLO buzzern
+- `POST /api/buzzer/skip` – Buzz überspringen

--- a/kiosk-backend/index.js
+++ b/kiosk-backend/index.js
@@ -19,6 +19,7 @@ import adminPurchases from './routes/admin/purchases.js';
 import adminStats from './routes/admin/stats.js';
 import adminUsers from './routes/admin/users.js';
 import adminBuyForUser from './routes/admin/buy_for_user.js';
+import buzzer from './routes/buzzer.js';
 import errorHandler from './middleware/errorHandler.js';
 import requestLogger from './middleware/requestLogger.js';
 import notFound from './middleware/notFound.js';
@@ -109,6 +110,7 @@ app.use('/api/admin/purchases', adminPurchases);
 app.use('/api/admin/stats', adminStats);
 app.use('/api/admin/users', adminUsers);
 app.use('/api/admin/buy', adminBuyForUser);
+app.use('/api/buzzer', buzzer);
 
 // 404-Handler
 app.use(notFound);

--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -69,6 +69,43 @@ async function init() {
   }
   await loadRound();
   await loadGeneralInfo();
+
+  document.getElementById('join-btn').addEventListener('click', joinRound);
+  document.getElementById('buzz-btn').addEventListener('click', buzz);
+  document.getElementById('skip-btn').addEventListener('click', skip);
 }
 
 document.addEventListener('DOMContentLoaded', init);
+
+async function joinRound() {
+  const res = await fetch(`${BACKEND_URL}/api/buzzer/join`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (res.ok) {
+    document.getElementById('join-btn').disabled = true;
+  }
+}
+
+async function buzz() {
+  const res = await fetch(`${BACKEND_URL}/api/buzzer/buzz`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (res.ok) {
+    document.getElementById('buzz-btn').disabled = true;
+  }
+}
+
+async function skip() {
+  const res = await fetch(`${BACKEND_URL}/api/buzzer/skip`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (res.ok) {
+    document.getElementById('skip-btn').disabled = true;
+  }
+}


### PR DESCRIPTION
## Summary
- document buzzer API in README
- expose new `/api/buzzer` routes
- wire frontend buttons to call buzzer API endpoints

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_6845f11cc54c8320af9c3f16f5e5b663