### PR TITLE
Fix buzzer frontend url error

### DIFF
--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -20,7 +20,6 @@
     <script>
       tailwind.config = { darkMode: 'class' };
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="buzzer.js" defer></script>
 
     <link

--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -1,10 +1,6 @@
 // buzzer.js – einfache Steuerung der Buzzer-Seite
 
-const SUPABASE_URL = 'SUPABASE_URL'; // TODO: anpassen
-const SUPABASE_ANON_KEY = 'SUPABASE_ANON_KEY'; // TODO: anpassen
-
 const BACKEND_URL = window.location.origin;
-const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
 function toggleDarkMode() {
   const isDark = document.documentElement.classList.toggle('dark');
@@ -29,11 +25,11 @@ async function checkUser() {
 }
 
 async function loadRound() {
-  const { data: round } = await supabase
-    .from('buzzer_rounds')
-    .select('*')
-    .eq('active', true)
-    .single();
+  const res = await fetch(`${BACKEND_URL}/api/buzzer/round`, {
+    credentials: 'include',
+  });
+  if (!res.ok) return;
+  const { round } = await res.json();
 
   const infoEl = document.getElementById('round-info');
   const joinBtn = document.getElementById('join-btn');
@@ -48,9 +44,11 @@ async function loadRound() {
 }
 
 async function loadGeneralInfo() {
-  const { data: online } = await supabase
-    .from('user_sessions')
-    .select('username, online, users(role)');
+  const res = await fetch(`${BACKEND_URL}/api/buzzer/sessions`, {
+    credentials: 'include',
+  });
+  if (!res.ok) return;
+  const { sessions: online } = await res.json();
   const container = document.getElementById('general-info');
   container.innerHTML = '';
   online?.forEach((u) => {

--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -19,6 +19,18 @@ router.get(
   }),
 );
 
+router.get(
+  '/sessions',
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    const { data, error } = await supabase
+      .from('user_sessions')
+      .select('username, online, users(role)');
+    if (error) return res.status(500).json({ error: 'Datenbankfehler' });
+    res.json({ sessions: data });
+  }),
+);
+
 router.post(
   '/round',
   requireAdmin,


### PR DESCRIPTION
## Summary
- drop direct Supabase usage in the buzzer page
- add new `/api/buzzer/sessions` endpoint
- fetch round and session info via backend

## Testing
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_b_6845f53810fc8320968b3d18d220f388