### PR TITLE
Fix buzzer round fetch handling and add dashboard link

### DIFF
--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -60,6 +60,15 @@
       </button>
     </div>
 
+    <div class="fixed top-4 left-4 z-50">
+      <a
+        href="dashboard.html"
+        class="bg-green-600 hover:bg-green-700 text-white font-bold py-1 px-3 rounded-full shadow text-sm"
+      >
+        ⬅️ Zurück zum Dashboard
+      </a>
+    </div>
+
     <div class="max-w-screen-md mx-auto mt-8 p-4 space-y-6">
       <h1 class="text-3xl font-bold text-center">Buzzer</h1>
 

--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -28,8 +28,12 @@ async function loadRound() {
   const res = await fetch(`${BACKEND_URL}/api/buzzer/round`, {
     credentials: 'include',
   });
-  if (!res.ok) return;
-  const { round } = await res.json();
+  let round = null;
+  if (res.status !== 404) {
+    if (!res.ok) return;
+    const data = await res.json();
+    round = data.round;
+  }
 
   const infoEl = document.getElementById('round-info');
   const joinBtn = document.getElementById('join-btn');


### PR DESCRIPTION
## Summary
- add a "Zurück zum Dashboard" link on the buzzer page
- handle 404 when fetching the active round so the page shows "Keine laufende Runde"

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_6845fa61414c8320b72ad1508b15af1d