### PR TITLE
Fix admin round start for buzzer

### DIFF
--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -117,7 +117,31 @@
         class="hidden p-4 border rounded-lg dark:border-gray-600"
       >
         <h2 class="text-xl font-semibold mb-2">Admin-Funktionen</h2>
-        <div id="admin-controls" class="space-y-2"></div>
+        <form id="round-form" class="space-y-2 mb-2">
+          <input
+            id="round-bet"
+            type="number"
+            min="1"
+            placeholder="Einsatz in Punkten"
+            class="p-2 border rounded w-full"
+            required
+          />
+          <input
+            id="round-limit"
+            type="number"
+            min="1"
+            placeholder="Punktelimit"
+            class="p-2 border rounded w-full"
+            required
+          />
+          <button
+            type="submit"
+            class="px-3 py-1 bg-green-600 text-white rounded"
+          >
+            Runde starten
+          </button>
+        </form>
+        <p id="admin-message" class="text-sm"></p>
       </section>
 
       <section


### PR DESCRIPTION
## Summary
- add CSRF helpers and admin form to buzzer UI
- send CSRF token when joining/skipping/buzzing
- allow admin to start rounds from UI

## Testing
- `npx prettier -w public/buzzer.js public/buzzer.html`
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6845fba31ff8832090c9ff86d3dab0df