### PR TITLE
Clarify Euro bet and emphasize button

### DIFF
--- a/docs/buzzer_flow.md
+++ b/docs/buzzer_flow.md
@@ -3,7 +3,7 @@
 Diese Datei beschreibt den kompletten Ablauf des Buzzer-Spiels, wie es in "Rischis Kiosk" umgesetzt ist. Die Logik basiert auf Supabase und einer einfachen Express API.
 
 ## 1. Rundenstart durch den Admin
-- Der Admin wählt Einsatz (z. B. 1 €) und Punktelimit (z. B. 5 Punkte).
+- Der Admin wählt einen Einsatz in Euro (z. B. 1 €) und ein Punktelimit (z. B. 5 Punkte).
 - Eine neue Runde wird in `buzzer_rounds` als aktiv gespeichert. Es kann immer nur eine aktive Runde geben.
 
 ## 2. Spieler beitreten

--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -99,7 +99,7 @@
         <div class="flex gap-2 mt-3">
           <button
             id="buzz-btn"
-            class="px-3 py-1 bg-blue-600 text-white rounded disabled:opacity-50"
+            class="px-8 py-4 text-2xl font-bold bg-blue-600 hover:bg-blue-700 text-white rounded shadow-lg transition-transform transform hover:scale-105 disabled:opacity-50"
           >
             Buzz
           </button>
@@ -122,7 +122,7 @@
             id="round-bet"
             type="number"
             min="1"
-            placeholder="Einsatz in Punkten"
+            placeholder="Einsatz in Euro"
             class="p-2 border rounded w-full"
             required
           />


### PR DESCRIPTION
## Summary
- revert docs to show bet in euros instead of points
- input placeholder now reads "Einsatz in Euro"
- bigger, bolder Buzz button for more focus

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6845fdaf474c8320a43579d788249b3d