### PR TITLE
Update buzzer bet instructions

### DIFF
--- a/docs/buzzer_flow.md
+++ b/docs/buzzer_flow.md
@@ -3,7 +3,7 @@
 Diese Datei beschreibt den kompletten Ablauf des Buzzer-Spiels, wie es in "Rischis Kiosk" umgesetzt ist. Die Logik basiert auf Supabase und einer einfachen Express API.
 
 ## 1. Rundenstart durch den Admin
-- Der Admin wählt einen Einsatz in Punkten (z. B. 1 Punkt) und ein Punktelimit (z. B. 5 Punkte).
+- Der Admin wählt einen Einsatz in Euro (z. B. 1 €) und ein Punktelimit (z. B. 5 Punkte) bevor eine Runde startet.
 - Eine neue Runde wird in `buzzer_rounds` als aktiv gespeichert. Es kann immer nur eine aktive Runde geben.
 
 ## 2. Spieler beitreten

--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -99,7 +99,7 @@
         <div class="flex gap-2 mt-3">
           <button
             id="buzz-btn"
-            class="px-6 py-3 text-xl bg-blue-600 text-white rounded disabled:opacity-50"
+            class="px-8 py-4 text-2xl font-bold bg-blue-600 text-white rounded shadow-lg hover:bg-blue-700 hover:shadow-xl hover:scale-105 transition transform disabled:opacity-50"
           >
             Buzz
           </button>
@@ -122,7 +122,7 @@
             id="round-bet"
             type="number"
             min="1"
-            placeholder="Einsatz in Punkten"
+            placeholder="Einsatz in Euro"
             class="p-2 border rounded w-full"
             required
           />

--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -51,7 +51,7 @@ async function loadRound() {
   const joinBtn = document.getElementById('join-btn');
 
   if (round) {
-    infoEl.textContent = `Einsatz: ${round.bet} Punkte, Limit: ${round.points_limit}`;
+    infoEl.textContent = `Einsatz: ${round.bet} €, Limit: ${round.points_limit}`;
     joinBtn.classList.remove('hidden');
   } else {
     infoEl.textContent = 'Keine laufende Runde';


### PR DESCRIPTION
## Summary
- clarify in docs that the admin chooses the bet in euros
- change admin placeholder to 'Einsatz in Euro'
- enlarge the Buzz button with hover effects
- show bet value as euros in the round info

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6846021ee23c8320ac3891cee3f72db9