### PR TITLE
Add skip button layout improvements

### DIFF
--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -96,7 +96,7 @@
         <div id="kolo-info" class="text-sm text-gray-700 dark:text-gray-300">
           Warte auf neues KOLO…
         </div>
-        <div class="flex gap-4 mt-6 justify-center">
+        <div class="flex flex-col items-center gap-2 mt-6">
           <button
             id="buzz-btn"
             class="px-16 py-8 text-4xl font-extrabold bg-gradient-to-br from-yellow-400 via-red-500 to-pink-600 text-white rounded-full shadow-lg hover:shadow-xl hover:scale-105 transition-transform disabled:opacity-50"
@@ -105,7 +105,7 @@
           </button>
           <button
             id="skip-btn"
-            class="px-3 py-1 bg-gray-500 text-white rounded disabled:opacity-50"
+            class="mt-2 px-2 py-1 text-xs bg-gray-500 text-white rounded disabled:opacity-50"
           >
             Skip
           </button>


### PR DESCRIPTION
## Summary
- stack the skip button below the Buzz button and shrink it

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684605444a0483209888762c932c5514