### PR TITLE
Fix buzzer round creation

### DIFF
--- a/kiosk-backend/middleware/validate.js
+++ b/kiosk-backend/middleware/validate.js
@@ -46,3 +46,11 @@ export const validateLogin = createValidator(loginSchema);
 export const validateRegister = createValidator(registerSchema);
 export const validateBuy = createValidator(buySchema);
 export const validateAdminBuy = createValidator(adminBuySchema);
+
+// Validierung für das Erstellen einer Buzzer-Runde
+const buzzerRoundSchema = z.object({
+  bet: z.coerce.number().int().positive(),
+  points_limit: z.coerce.number().int().positive(),
+});
+
+export const validateBuzzerRound = createValidator(buzzerRoundSchema);

--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import supabase from '../utils/supabase.js';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
+import { validateBuzzerRound } from '../middleware/validate.js';
 import asyncHandler from '../utils/asyncHandler.js';
 
 const router = express.Router();
@@ -42,6 +43,7 @@ router.get(
 router.post(
   '/round',
   requireAdmin,
+  validateBuzzerRound,
   asyncHandler(async (req, res) => {
     const { bet, points_limit } = req.body;
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- validate admin input when creating a buzzer round

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6846089b81f483208a50398a6408d9a6