### PR TITLE
Fix round creation by adding end round button

### DIFF
--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -141,6 +141,12 @@
             Runde starten
           </button>
         </form>
+        <button
+          id="end-round-btn"
+          class="mb-2 px-3 py-1 bg-red-600 text-white rounded hidden"
+        >
+          Runde beenden
+        </button>
         <p id="admin-message" class="text-sm"></p>
       </section>
 


### PR DESCRIPTION
## Summary
- add button in buzzer admin section to end the current round
- implement `endRound` client function and show/hide button based on round state
- keep track of current user for admin features

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68460d2ed1708320becab98482374b83