### PR TITLE
Handle Supabase errors when starting buzzer round

### DIFF
--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -46,11 +46,20 @@ router.post(
   validateBuzzerRound,
   asyncHandler(async (req, res) => {
     const { bet, points_limit } = req.body;
-    const { data: existing } = await supabase
+    const {
+      data: existing,
+      error: existingError,
+    } = await supabase
       .from('buzzer_rounds')
       .select('id')
       .eq('active', true)
       .maybeSingle();
+
+    if (existingError) {
+      return res
+        .status(500)
+        .json({ error: 'Runde konnte nicht erstellt werden' });
+    }
 
     if (existing)
       return res.status(400).json({ error: 'Es läuft bereits eine Runde' });


### PR DESCRIPTION
## Summary
- handle errors from Supabase when checking if a buzzer round already exists

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68460f2d8634832087fba4732c150211