### PR TITLE
Improve error logging for buzzer round creation

### DIFF
--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -56,6 +56,7 @@ router.post(
       .maybeSingle();
 
     if (existingError) {
+      console.error('createRound existingError', existingError);
       return res
         .status(500)
         .json({ error: 'Runde konnte nicht erstellt werden' });
@@ -69,10 +70,12 @@ router.post(
       .insert({ bet, points_limit, active: true })
       .select()
       .single();
-    if (error)
+    if (error) {
+      console.error('createRound insert error', error);
       return res
         .status(500)
         .json({ error: 'Runde konnte nicht erstellt werden' });
+    }
     res.json({ round: data });
   }),
 );


### PR DESCRIPTION
## Summary
- add console output for database errors during round creation to help debugging

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_68461178b9008320a57134b7a2d1ed4d