### PR TITLE
Fix join errors by generating UUIDs for buzzer tables

### DIFF
--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import { randomUUID } from 'node:crypto';
 import supabase from '../utils/supabase.js';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
 import { validateBuzzerRound } from '../middleware/validate.js';
@@ -46,10 +47,7 @@ router.post(
   validateBuzzerRound,
   asyncHandler(async (req, res) => {
     const { bet, points_limit } = req.body;
-    const {
-      data: existing,
-      error: existingError,
-    } = await supabase
+    const { data: existing, error: existingError } = await supabase
       .from('buzzer_rounds')
       .select('id')
       .eq('active', true)
@@ -67,7 +65,7 @@ router.post(
 
     const { data, error } = await supabase
       .from('buzzer_rounds')
-      .insert({ bet, points_limit, active: true })
+      .insert({ id: randomUUID(), bet, points_limit, active: true })
       .select()
       .single();
     if (error) {
@@ -119,7 +117,7 @@ router.post(
     if (!round) return res.status(400).json({ error: 'Keine aktive Runde' });
     const { error } = await supabase
       .from('buzzer_participants')
-      .insert({ round_id: round.id, user_id: userId });
+      .insert({ id: randomUUID(), round_id: round.id, user_id: userId });
     if (error)
       return res.status(500).json({ error: 'Teilnahme fehlgeschlagen' });
     res.json({ joined: true });
@@ -147,7 +145,7 @@ router.post(
     if (!kolo) return res.status(400).json({ error: 'Kein aktives KOLO' });
     const { error } = await supabase
       .from('buzzes')
-      .insert({ kolo_id: kolo.id, user_id: userId });
+      .insert({ id: randomUUID(), kolo_id: kolo.id, user_id: userId });
     if (error) return res.status(500).json({ error: 'Buzz fehlgeschlagen' });
     res.json({ buzzed: true });
   }),
@@ -174,7 +172,7 @@ router.post(
     if (!kolo) return res.status(400).json({ error: 'Kein aktives KOLO' });
     const { error } = await supabase
       .from('skips')
-      .insert({ kolo_id: kolo.id, user_id: userId });
+      .insert({ id: randomUUID(), kolo_id: kolo.id, user_id: userId });
     if (error) return res.status(500).json({ error: 'Skip fehlgeschlagen' });
     res.json({ skipped: true });
   }),


### PR DESCRIPTION
## Summary
- generate UUIDs in the buzzer router when inserting new rows

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684612e81c5083208b2bba2620009fc3