### PR TITLE
Implement admin round lock

### DIFF
--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -147,6 +147,12 @@
           </button>
         </form>
         <button
+          id="lock-round-btn"
+          class="mb-2 px-3 py-1 bg-yellow-600 text-white rounded hidden"
+        >
+          Runde vollständig
+        </button>
+        <button
           id="end-round-btn"
           class="mb-2 px-3 py-1 bg-red-600 text-white rounded hidden"
         >


### PR DESCRIPTION
## Summary
- allow admin to mark round as full via `/api/buzzer/round/lock`
- show lock button in admin UI and update round loading logic
- prevent joining once a round has been locked

## Testing
- `npm run lint`
- `npx prettier --write public/buzzer.html public/buzzer.js routes/buzzer.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68461d7b16208320b8af1363056c7021