### PR TITLE
Improve buzzer round error message

### DIFF
--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -233,6 +233,7 @@ async function createRound(e) {
   } else {
     const data = await res.json().catch(() => ({}));
     msgEl.textContent = data.error || 'Fehler beim Start';
+    if (data.detail) msgEl.textContent += `: ${data.detail}`;
   }
   setTimeout(() => {
     msgEl.textContent = '';

--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -99,9 +99,10 @@ router.post(
 
     if (existingError) {
       console.error('createRound existingError', existingError);
-      return res
-        .status(500)
-        .json({ error: 'Runde konnte nicht erstellt werden' });
+      return res.status(500).json({
+        error: 'Runde konnte nicht erstellt werden',
+        detail: existingError.message,
+      });
     }
 
     if (existing)
@@ -120,9 +121,10 @@ router.post(
       .single();
     if (error) {
       console.error('createRound insert error', error);
-      return res
-        .status(500)
-        .json({ error: 'Runde konnte nicht erstellt werden' });
+      return res.status(500).json({
+        error: 'Runde konnte nicht erstellt werden',
+        detail: error.message,
+      });
     }
     res.json({ round: data });
   }),


### PR DESCRIPTION
## Summary
- bubble up Supabase error details when creating a buzzer round fails
- show the error detail in the admin UI

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684621cab63883208c7688e835858b98