### PR TITLE
Fix joinable flag when ending round

### DIFF
--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -164,7 +164,7 @@ router.post(
 
     const { error } = await supabase
       .from('buzzer_rounds')
-      .update({ active: false })
+      .update({ active: false, joinable: false })
       .eq('id', round.id);
 
     if (error)


### PR DESCRIPTION
## Summary
- mark rounds as not joinable when ending them

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684625c76bb08320afa6ca877664a835