### PR TITLE
Add KOLO start/end controls to buzzer admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ npm run lint     # Code mit ESLint prüfen
 npm run format   # Code mit Prettier formatieren
 ```
 
+## Tools
+
+Neben Linting und Formatierung stehen noch weitere npm-Skripte zur
+Verfügung, die den Entwicklungsalltag erleichtern:
+
+```bash
+npm start        # Express-Server starten
+npm test         # Tests ausführen (Platzhalter)
+npm run lint     # Code mit ESLint prüfen
+npm run format   # Code mit Prettier formatieren
+```
+
 ## Buzzer-Spiel
 
 Das Buzzer-Spiel ermöglicht schnelle Musikquiz-Runden. Es nutzt Supabase für Authentifizierung, Datenbankzugriffe und Realtime-Channels.
@@ -84,5 +96,7 @@ Das Buzzer-Spiel ermöglicht schnelle Musikquiz-Runden. Es nutzt Supabase für A
 - `POST /api/buzzer/join` – aktueller Runde beitreten
 - `POST /api/buzzer/buzz` – im laufenden KOLO buzzern
 - `POST /api/buzzer/skip` – Buzz überspringen
+- `POST /api/buzzer/kolo` – neues KOLO starten (Admin)
+- `POST /api/buzzer/kolo/end` – KOLO beenden und werten (Admin)
 
 Weitere Details zum kompletten Ablauf finden sich in [docs/buzzer_flow.md](docs/buzzer_flow.md).

--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -158,6 +158,28 @@
         >
           Runde beenden
         </button>
+        <div id="kolo-controls" class="space-y-2 mt-4">
+          <button
+            id="start-kolo-btn"
+            class="px-3 py-1 bg-blue-600 text-white rounded w-full"
+          >
+            KOLO starten
+          </button>
+          <div class="flex gap-2">
+            <button
+              id="kolo-correct-btn"
+              class="flex-1 px-3 py-1 bg-green-600 text-white rounded"
+            >
+              Korrekt
+            </button>
+            <button
+              id="kolo-wrong-btn"
+              class="flex-1 px-3 py-1 bg-red-600 text-white rounded"
+            >
+              Falsch
+            </button>
+          </div>
+        </div>
         <p id="admin-message" class="text-sm"></p>
       </section>
 

--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -140,6 +140,15 @@ async function init() {
     document
       .getElementById('lock-round-btn')
       ?.addEventListener('click', lockRound);
+    document
+      .getElementById('start-kolo-btn')
+      ?.addEventListener('click', startKolo);
+    document
+      .getElementById('kolo-correct-btn')
+      ?.addEventListener('click', () => endKolo(true));
+    document
+      .getElementById('kolo-wrong-btn')
+      ?.addEventListener('click', () => endKolo(false));
   }
   await loadRound();
   await loadParticipants();
@@ -271,6 +280,48 @@ async function endRound(e) {
     msgEl.textContent = 'Runde beendet';
     await loadRound();
     await loadParticipants();
+  } else {
+    const data = await res.json().catch(() => ({}));
+    msgEl.textContent = data.error || 'Fehler beim Beenden';
+  }
+  setTimeout(() => {
+    msgEl.textContent = '';
+  }, 3000);
+}
+
+async function startKolo(e) {
+  e.preventDefault();
+  const token = await getCsrfToken();
+  const res = await fetch(`${BACKEND_URL}/api/buzzer/kolo`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'x-csrf-token': token },
+  });
+  const msgEl = document.getElementById('admin-message');
+  if (res.ok) {
+    msgEl.textContent = 'KOLO gestartet';
+  } else {
+    const data = await res.json().catch(() => ({}));
+    msgEl.textContent = data.error || 'Fehler beim Starten';
+  }
+  setTimeout(() => {
+    msgEl.textContent = '';
+  }, 3000);
+}
+
+async function endKolo(correct) {
+  const token = await getCsrfToken();
+  const res = await fetch(`${BACKEND_URL}/api/buzzer/kolo/end`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'x-csrf-token': token },
+    body: JSON.stringify({ correct }),
+  });
+  const msgEl = document.getElementById('admin-message');
+  if (res.ok) {
+    msgEl.textContent = 'KOLO beendet';
+    await loadParticipants();
+    await loadGeneralInfo();
   } else {
     const data = await res.json().catch(() => ({}));
     msgEl.textContent = data.error || 'Fehler beim Beenden';


### PR DESCRIPTION
## Summary
- show KOLO start and evaluation buttons in buzzer admin panel
- implement `startKolo` and `endKolo` actions in `buzzer.js`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6846273736788320a292b9991eccbeb6