### PR TITLE
Improve KOLO button visibility

### DIFF
--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -158,7 +158,7 @@
         >
           Runde beenden
         </button>
-        <div id="kolo-controls" class="space-y-2 mt-4">
+        <div id="kolo-controls" class="space-y-2 mt-4 hidden">
           <button
             id="start-kolo-btn"
             class="px-3 py-1 bg-blue-600 text-white rounded w-full"

--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -55,6 +55,7 @@ async function loadRound() {
   const joinBtn = document.getElementById('join-btn');
   const endBtn = document.getElementById('end-round-btn');
   const lockBtn = document.getElementById('lock-round-btn');
+  const koloControls = document.getElementById('kolo-controls');
 
   if (round) {
     infoEl.textContent = `Einsatz: ${round.bet} €, Limit: ${round.points_limit}`;
@@ -65,12 +66,16 @@ async function loadRound() {
       joinBtn.classList.remove('hidden');
       if (currentUser?.role === 'admin') lockBtn?.classList.remove('hidden');
     }
-    if (currentUser?.role === 'admin') endBtn?.classList.remove('hidden');
+    if (currentUser?.role === 'admin') {
+      endBtn?.classList.remove('hidden');
+      koloControls?.classList.remove('hidden');
+    }
   } else {
     infoEl.textContent = 'Keine laufende Runde';
     joinBtn.classList.add('hidden');
     endBtn?.classList.add('hidden');
     lockBtn?.classList.add('hidden');
+    koloControls?.classList.add('hidden');
   }
 }
 


### PR DESCRIPTION
## Summary
- hide KOLO controls by default
- show KOLO controls only when a round is active

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68462cd552b48320b942561c7cc9e0fa