### PR TITLE
Hide round form when active round exists

### DIFF
--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -56,9 +56,11 @@ async function loadRound() {
   const endBtn = document.getElementById('end-round-btn');
   const lockBtn = document.getElementById('lock-round-btn');
   const koloControls = document.getElementById('kolo-controls');
+  const roundForm = document.getElementById('round-form');
 
   if (round) {
     infoEl.textContent = `Einsatz: ${round.bet} €, Limit: ${round.points_limit}`;
+    if (roundForm) roundForm.classList.add('hidden');
     if (round.joinable === false) {
       joinBtn.classList.add('hidden');
       lockBtn?.classList.add('hidden');
@@ -72,6 +74,7 @@ async function loadRound() {
     }
   } else {
     infoEl.textContent = 'Keine laufende Runde';
+    roundForm?.classList.remove('hidden');
     joinBtn.classList.add('hidden');
     endBtn?.classList.add('hidden');
     lockBtn?.classList.add('hidden');


### PR DESCRIPTION
## Summary
- hide round start fields when a round is already active on buzzer page

## Testing
- `npm run lint`
- `npx prettier --write public/buzzer.js`

------
https://chatgpt.com/codex/tasks/task_b_684633aab1348320bc2ff289a669b4d7