### PR TITLE
Clarify COOKIE_SECURE usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Legen Sie eine `.env` Datei im Verzeichnis `kiosk-backend` an oder nutzen Sie di
 | `NODE_ENV`              | Bei `production` werden nur Anfragen von `.de` Domains zugelassen |
 | `BANK_USER_NAME`        | Name des System-Users für Buzzer-Auszahlungen (optional) |
 
+**Hinweis:** Wenn der Server lediglich per HTTP erreichbar ist (beispielsweise bei lokalen Tests), muss `COOKIE_SECURE=false` gesetzt sein. Andernfalls wird das Session-Cookie nicht übertragen und Sie werden beim Seitenwechsel ausgeloggt.
+
 Beim Start des Servers werden diese Variablen mit einem Zod-Schema
 validiert. Fehlen erforderliche Werte oder sind sie ungültig, wird der
 Start abgebrochen.


### PR DESCRIPTION
## Summary
- document that COOKIE_SECURE must be `false` when the server runs without HTTPS

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6846c909a1b48320a2ecb414a69345e2