### PR TITLE
Improve poker win animation

### DIFF
--- a/kiosk-backend/public/poker.html
+++ b/kiosk-backend/public/poker.html
@@ -64,6 +64,28 @@
         background-color: #374151;
         color: white;
       }
+
+      @keyframes win-pop {
+        0% {
+          transform: scale(0.8);
+          opacity: 0;
+        }
+        50% {
+          transform: scale(1.2);
+          opacity: 1;
+        }
+        100% {
+          transform: scale(1);
+          opacity: 1;
+        }
+      }
+
+      .win-animation {
+        color: #16a34a;
+        font-weight: 700;
+        font-size: 1.5rem;
+        animation: win-pop 0.8s ease-out;
+      }
     </style>
   </head>
   <body class="text-green-900 dark:text-white">

--- a/kiosk-backend/public/poker.js
+++ b/kiosk-backend/public/poker.js
@@ -50,9 +50,15 @@ async function playPoker() {
     userBalance = data.newBalance;
     document.getElementById('balance').textContent =
       `${userBalance.toFixed(2)} €`;
-    document.getElementById('result').textContent = data.win
-      ? 'Gewonnen!'
-      : 'Verloren!';
+    const resultEl = document.getElementById('result');
+    resultEl.textContent = data.win ? 'Gewonnen!' : 'Verloren!';
+    if (data.win) {
+      resultEl.classList.add('win-animation');
+    }
+    setTimeout(() => {
+      resultEl.textContent = '';
+      resultEl.classList.remove('win-animation');
+    }, 2000);
   } catch (err) {
     console.error(err);
     document.getElementById('result').textContent = 'Fehler beim Spiel';


### PR DESCRIPTION
## Summary
- add win pop animation
- show win message briefly

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`
- `npx prettier --write kiosk-backend/public/poker.html kiosk-backend/public/poker.js`

------
https://chatgpt.com/codex/tasks/task_b_6847309012a48320971cbd8c11f795ab