### PR TITLE
Implement bank account helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Legen Sie eine `.env` Datei im Verzeichnis `kiosk-backend` an oder nutzen Sie di
 | `COOKIE_SAMESITE`       | Wert für das SameSite-Attribut                                    |
 | `FORCE_HTTPS`           | `true` leitet HTTP-Anfragen auf HTTPS um                          |
 | `NODE_ENV`              | Bei `production` werden nur Anfragen von `.de` Domains zugelassen |
-| `BANK_USER_NAME`        | Name des System-Users für Buzzer-Auszahlungen und Poker-Gewinne (optional) |
+| `BANK_USER_NAME`        | Name des System-Users für Buzzer-Auszahlungen und Poker-Gewinne (optional). Muss exakt dem Wert in `users.name` entsprechen |
 
 **Hinweis:** Wenn der Server lediglich per HTTP erreichbar ist (beispielsweise bei lokalen Tests), muss `COOKIE_SECURE=false` gesetzt sein. Andernfalls wird das Session-Cookie nicht übertragen und Sie werden beim Seitenwechsel ausgeloggt.
 

--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -5,6 +5,7 @@ import { requireAuth, requireAdmin } from '../middleware/auth.js';
 import { validateBuzzerRound } from '../middleware/validate.js';
 import asyncHandler from '../utils/asyncHandler.js';
 import env from '../utils/env.js';
+import { creditBank } from '../utils/bank.js';
 
 const router = express.Router();
 const BANK_USER_NAME = env.BANK_USER_NAME;
@@ -197,18 +198,7 @@ router.post(
         .update({ balance: (winUser?.balance || 0) + winnerShare })
         .eq('id', winner.user_id);
 
-      if (BANK_USER_NAME) {
-        const { data: bank } = await supabase
-          .from('users')
-          .select('id, balance')
-          .eq('name', BANK_USER_NAME)
-          .maybeSingle();
-        if (bank)
-          await supabase
-            .from('users')
-            .update({ balance: (bank.balance || 0) + bankShare })
-            .eq('id', bank.id);
-      }
+      await creditBank(bankShare);
     }
 
     res.json({ ended: true });

--- a/kiosk-backend/routes/poker.js
+++ b/kiosk-backend/routes/poker.js
@@ -3,6 +3,7 @@ import supabase from '../utils/supabase.js';
 import { requireAuth } from '../middleware/auth.js';
 import asyncHandler from '../utils/asyncHandler.js';
 import env from '../utils/env.js';
+import { creditBank } from '../utils/bank.js';
 
 const BANK_USER_NAME = env.BANK_USER_NAME;
 
@@ -32,17 +33,8 @@ router.post(
     let newBalance = user.balance - bet;
     if (win) {
       newBalance += bet * 2;
-    } else if (BANK_USER_NAME) {
-      const { data: bank } = await supabase
-        .from('users')
-        .select('id, balance')
-        .eq('name', BANK_USER_NAME)
-        .maybeSingle();
-      if (bank)
-        await supabase
-          .from('users')
-          .update({ balance: (bank.balance || 0) + bet })
-          .eq('id', bank.id);
+    } else {
+      await creditBank(bet);
     }
 
     const { error: upErr } = await supabase

--- a/kiosk-backend/utils/bank.js
+++ b/kiosk-backend/utils/bank.js
@@ -1,0 +1,21 @@
+import supabase from './supabase.js';
+import env from './env.js';
+
+/**
+ * Credit the bank account identified by BANK_USER_NAME.
+ * @param {number} amount Amount to add to the bank balance
+ */
+export async function creditBank(amount) {
+  if (!env.BANK_USER_NAME || !amount || amount <= 0) return;
+  const { data: bank } = await supabase
+    .from('users')
+    .select('id, balance')
+    .eq('name', env.BANK_USER_NAME)
+    .maybeSingle();
+  if (bank) {
+    await supabase
+      .from('users')
+      .update({ balance: (bank.balance || 0) + amount })
+      .eq('id', bank.id);
+  }
+}

--- a/kiosk-backend/utils/purchaseProduct.js
+++ b/kiosk-backend/utils/purchaseProduct.js
@@ -1,5 +1,6 @@
 import supabase from './supabase.js';
 import env from './env.js';
+import { creditBank } from './bank.js';
 
 export default async function purchaseProduct(user, product, quantity) {
   const total = quantity * product.price;
@@ -24,19 +25,7 @@ export default async function purchaseProduct(user, product, quantity) {
     throw err;
   }
 
-  if (env.BANK_USER_NAME) {
-    const { data: bank } = await supabase
-      .from('users')
-      .select('id, balance')
-      .eq('name', env.BANK_USER_NAME)
-      .maybeSingle();
-    if (bank) {
-      await supabase
-        .from('users')
-        .update({ balance: (bank.balance || 0) + total })
-        .eq('id', bank.id);
-    }
-  }
+  await creditBank(total);
 
   return { success: true };
 }


### PR DESCRIPTION
## Summary
- add `creditBank` helper to centralize bank account updates
- use `creditBank` in purchase flow, poker game, and buzzer payout
- document that `BANK_USER_NAME` must match the `users.name` field

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_684734806e3c8320af8c2ac9cc0f9451