### PR TITLE
Fix bank balance for poker wins

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,6 @@ Zock Royale ist ein kleines Spaß-Pokerspiel. Über `/api/poker/play` kannst du
 einen Einsatz platzieren. In 40 % der Fälle gewinnt der Spieler und erhält das
 Doppelte seines Einsatzes. Verliert der Spieler, landet der Einsatz auf dem
 Konto, das in `BANK_USER_NAME` hinterlegt ist (in der Regel der „Haus“-Account).
-Somit hat das Haus eine Gewinnchance von 60 %. Das Ergebnis wird im
+Gewinnt der Spieler, zahlt das Haus den doppelten Einsatz aus seinem Guthaben
+an den Spieler aus. Somit hat das Haus eine Gewinnchance von 60 %. Das Ergebnis wird im
 Nutzerkonto gespeichert.

--- a/kiosk-backend/routes/poker.js
+++ b/kiosk-backend/routes/poker.js
@@ -3,7 +3,7 @@ import supabase from '../utils/supabase.js';
 import { requireAuth } from '../middleware/auth.js';
 import asyncHandler from '../utils/asyncHandler.js';
 import env from '../utils/env.js';
-import { creditBank } from '../utils/bank.js';
+import { creditBank, debitBank } from '../utils/bank.js';
 
 const BANK_USER_NAME = env.BANK_USER_NAME;
 
@@ -33,6 +33,7 @@ router.post(
     let newBalance = user.balance - bet;
     if (win) {
       newBalance += bet * 2;
+      await debitBank(bet * 2);
     } else {
       await creditBank(bet);
     }

--- a/kiosk-backend/utils/bank.js
+++ b/kiosk-backend/utils/bank.js
@@ -19,3 +19,22 @@ export async function creditBank(amount) {
       .eq('id', bank.id);
   }
 }
+
+/**
+ * Debit the bank account identified by BANK_USER_NAME.
+ * @param {number} amount Amount to subtract from the bank balance
+ */
+export async function debitBank(amount) {
+  if (!env.BANK_USER_NAME || !amount || amount <= 0) return;
+  const { data: bank } = await supabase
+    .from('users')
+    .select('id, balance')
+    .eq('name', env.BANK_USER_NAME)
+    .maybeSingle();
+  if (bank) {
+    await supabase
+      .from('users')
+      .update({ balance: (bank.balance || 0) - amount })
+      .eq('id', bank.id);
+  }
+}


### PR DESCRIPTION
## Summary
- deduct double the bet from the house when user wins
- clarify README that the house pays out the doubled bet

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68473c71062c832090d5fa4e834090c9