### PR TITLE
Improve Zock Royale animation and UI

### DIFF
--- a/kiosk-backend/public/poker.html
+++ b/kiosk-backend/public/poker.html
@@ -109,6 +109,51 @@
         font-size: 1.5rem;
         animation: lose-shake 0.8s ease-in-out;
       }
+
+      @keyframes balance-pop {
+        0% {
+          transform: scale(1);
+        }
+        50% {
+          transform: scale(1.2);
+        }
+        100% {
+          transform: scale(1);
+        }
+      }
+
+      .balance-update {
+        animation: balance-pop 0.6s ease-out;
+      }
+
+      .result-card {
+        padding: 0.75rem;
+        border-radius: 1rem;
+        font-weight: 700;
+        margin-top: 0.5rem;
+        color: white;
+        transform: scale(0);
+        opacity: 0;
+        transition: transform 0.3s, opacity 0.3s;
+      }
+      .result-show {
+        transform: scale(1);
+        opacity: 1;
+      }
+      .result-win {
+        background-color: #16a34a;
+      }
+      .result-lose {
+        background-color: #dc2626;
+      }
+
+      #play {
+        transition: transform 0.1s;
+      }
+
+      #play:active {
+        transform: scale(0.95);
+      }
     </style>
   </head>
   <body class="text-green-900 dark:text-white">
@@ -149,7 +194,9 @@
           >
             Spielen
           </button>
-          <p id="result" class="text-center"></p>
+          <div id="result-card" class="result-card text-center hidden">
+            <span id="result"></span>
+          </div>
         </div>
       </div>
     </div>

--- a/kiosk-backend/public/poker.js
+++ b/kiosk-backend/public/poker.js
@@ -15,6 +15,9 @@ async function getCsrfToken() {
 
 let userBalance = 0;
 
+const balanceEl = document.getElementById('balance');
+const resultCard = document.getElementById('result-card');
+
 function launchConfetti() {
   if (typeof confetti === 'function') {
     confetti({ particleCount: 80, spread: 60, origin: { y: 0.6 } });
@@ -40,7 +43,15 @@ async function playPoker() {
   const betInput = document.getElementById('bet');
   const bet = parseFloat(betInput.value.replace(',', '.'));
   if (!bet || bet <= 0) {
-    document.getElementById('result').textContent = 'Ungültiger Einsatz';
+    const resultEl = document.getElementById('result');
+    resultEl.textContent = 'Ungültiger Einsatz';
+    resultCard.classList.remove('result-win', 'result-lose', 'hidden');
+    resultCard.classList.add('result-show', 'result-lose');
+    setTimeout(() => {
+      resultCard.classList.add('hidden');
+      resultCard.classList.remove('result-show', 'result-lose');
+      resultEl.textContent = '';
+    }, 1500);
     return;
   }
   try {
@@ -54,10 +65,12 @@ async function playPoker() {
     const data = await res.json();
     if (!res.ok) throw new Error(data.error || 'Fehler');
     userBalance = data.newBalance;
-    document.getElementById('balance').textContent =
-      `${userBalance.toFixed(2)} €`;
+    balanceEl.textContent = `${userBalance.toFixed(2)} €`;
+    balanceEl.classList.add('balance-update');
     const resultEl = document.getElementById('result');
     resultEl.textContent = data.win ? 'Gewonnen!' : 'Verloren!';
+    resultCard.classList.remove('hidden', 'result-win', 'result-lose');
+    resultCard.classList.add('result-show', data.win ? 'result-win' : 'result-lose');
     if (data.win) {
       resultEl.classList.add('win-animation');
       launchConfetti();
@@ -65,12 +78,23 @@ async function playPoker() {
       resultEl.classList.add('lose-animation');
     }
     setTimeout(() => {
+      resultCard.classList.add('hidden');
+      resultCard.classList.remove('result-show', 'result-win', 'result-lose');
       resultEl.textContent = '';
       resultEl.classList.remove('win-animation', 'lose-animation');
+      balanceEl.classList.remove('balance-update');
     }, 2000);
   } catch (err) {
     console.error(err);
-    document.getElementById('result').textContent = 'Fehler beim Spiel';
+    const resultEl = document.getElementById('result');
+    resultEl.textContent = 'Fehler beim Spiel';
+    resultCard.classList.remove('result-win', 'result-lose', 'hidden');
+    resultCard.classList.add('result-show', 'result-lose');
+    setTimeout(() => {
+      resultCard.classList.add('hidden');
+      resultCard.classList.remove('result-show', 'result-win', 'result-lose');
+      resultEl.textContent = '';
+    }, 2000);
   }
 }
 


### PR DESCRIPTION
## Summary
- animate Zock Royale results with flip card effect
- highlight balance changes and button press
- show a card for errors or invalid bets

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68474a0a631c83209ac93cf5d0f9e9dc