### PR TITLE
Improve Zock Royale usability

### DIFF
--- a/kiosk-backend/public/poker.js
+++ b/kiosk-backend/public/poker.js
@@ -1,12 +1,16 @@
 const BACKEND_URL = window.location.origin;
 
+let csrfToken;
+
 async function getCsrfToken() {
+  if (csrfToken) return csrfToken;
   try {
     const res = await fetch(`${BACKEND_URL}/api/csrf-token`, {
       credentials: 'include',
     });
     const data = await res.json();
-    return data.csrfToken;
+    csrfToken = data.csrfToken;
+    return csrfToken;
   } catch (err) {
     console.error('CSRF-Token konnte nicht geladen werden', err);
     return null;
@@ -54,6 +58,8 @@ async function playPoker() {
     }, 1500);
     return;
   }
+  const playBtn = document.getElementById('play');
+  playBtn.disabled = true;
   try {
     const token = await getCsrfToken();
     const res = await fetch(`${BACKEND_URL}/api/poker/play`, {
@@ -86,6 +92,7 @@ async function playPoker() {
       resultEl.textContent = '';
       resultEl.classList.remove('win-animation', 'lose-animation');
       balanceEl.classList.remove('balance-update');
+      playBtn.disabled = false;
     }, 2000);
   } catch (err) {
     console.error(err);
@@ -97,13 +104,19 @@ async function playPoker() {
       resultCard.classList.add('hidden');
       resultCard.classList.remove('result-show', 'result-win', 'result-lose');
       resultEl.textContent = '';
+      playBtn.disabled = false;
     }, 2000);
   }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
   loadUser();
-  document.getElementById('play').addEventListener('click', playPoker);
+  const playBtn = document.getElementById('play');
+  playBtn.addEventListener('click', playPoker);
+  getCsrfToken();
+  document.getElementById('bet').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') playPoker();
+  });
   const betInput = document.getElementById('bet');
   document.querySelectorAll('.quick-bet').forEach((btn) => {
     btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- cache CSRF token to avoid redundant requests
- disable Play button while request is pending and allow Enter key to start game

## Testing
- `npm --prefix kiosk-backend run lint`
- `npm --prefix kiosk-backend test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68474dd87dd88320ba82dbf0c61aee55