### PR TITLE
Restrict Zock Royale to positive balance

### DIFF
--- a/kiosk-backend/public/poker.js
+++ b/kiosk-backend/public/poker.js
@@ -97,7 +97,7 @@ async function playPoker() {
   } catch (err) {
     console.error(err);
     const resultEl = document.getElementById('result');
-    resultEl.textContent = 'Fehler beim Spiel';
+    resultEl.textContent = err.message || 'Fehler beim Spiel';
     resultCard.classList.remove('result-win', 'result-lose', 'hidden');
     resultCard.classList.add('result-show', 'result-lose');
     setTimeout(() => {

--- a/kiosk-backend/routes/poker.js
+++ b/kiosk-backend/routes/poker.js
@@ -25,7 +25,13 @@ router.post(
       .eq('id', userId)
       .single();
     if (error) return res.status(500).json({ error: 'Datenbankfehler' });
-    if (!user || (user.balance || 0) < bet) {
+    if (!user) return res.status(404).json({ error: 'Nutzer nicht gefunden' });
+    if (user.balance < 0) {
+      return res
+        .status(400)
+        .json({ error: 'Guthaben im Minus. Bitte zuerst bei Rischi zahlen.' });
+    }
+    if (user.balance < bet) {
       return res.status(400).json({ error: 'Nicht genug Guthaben' });
     }
 


### PR DESCRIPTION
## Summary
- improve poker route to deny play for users with negative balance
- show backend error messages on the poker page

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68474fa5a11c8320873ce2834b7aa9eb