### PR TITLE
Enhance Zock Royale gameplay

### DIFF
--- a/kiosk-backend/routes/poker.js
+++ b/kiosk-backend/routes/poker.js
@@ -1,56 +1,101 @@
 import express from 'express';
-import supabase from '../utils/supabase.js';
 import { requireAuth } from '../middleware/auth.js';
 import asyncHandler from '../utils/asyncHandler.js';
-import env from '../utils/env.js';
-import { creditBank, debitBank } from '../utils/bank.js';
-
-const BANK_USER_NAME = env.BANK_USER_NAME;
+import { playPokerRound } from '../services/pokerService.js';
+import supabase from '../utils/supabase.js';
 
 const router = express.Router();
+
+const messages = {
+  loss: [
+    '🙈 Leider verloren! Dein Einsatz ist weg.',
+    '😢 Pech gehabt, vielleicht nächstes Mal!',
+    '👎 Das war nichts – versuch es nochmal!',
+  ],
+  win: [
+    '🎉 Gewonnen! Dein Einsatz hat sich verdoppelt!',
+    '🥳 Glückwunsch zum Sieg! +100%!',
+  ],
+  jackpot: [
+    '🔥 JACKPOT! Unglaublich!',
+    '💥 Was für ein Treffer! Jackpot!',
+    '✨ Du räumst richtig ab – Jackpot!',
+  ],
+};
+
+function randomMessage(type) {
+  const arr = messages[type] || [];
+  return arr[Math.floor(Math.random() * arr.length)] || '';
+}
+
+async function getStats(userId) {
+  const [{ count: total }, { count: wins }, { count: jackpots }] =
+    await Promise.all([
+      supabase
+        .from('poker_rounds')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId),
+      supabase
+        .from('poker_rounds')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId)
+        .neq('result', 'loss'),
+      supabase
+        .from('poker_rounds')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId)
+        .eq('result', 'jackpot'),
+    ]);
+
+  const gamesPlayed = total || 0;
+  const winRate = gamesPlayed
+    ? `${(((wins || 0) / gamesPlayed) * 100).toFixed(1)}%`
+    : '0%';
+  return {
+    gamesPlayed,
+    winRate,
+    jackpots: jackpots || 0,
+  };
+}
 
 router.post(
   '/play',
   requireAuth,
   asyncHandler(async (req, res) => {
     const userId = req.user.id;
-    const bet = parseFloat(req.body.bet);
-    if (!bet || bet <= 0) {
+    const amount = parseFloat(req.body.bet);
+    if (!amount || amount <= 0) {
       return res.status(400).json({ error: 'Ungültiger Einsatz' });
     }
 
-    const { data: user, error } = await supabase
-      .from('users')
-      .select('balance')
-      .eq('id', userId)
-      .single();
-    if (error) return res.status(500).json({ error: 'Datenbankfehler' });
-    if (!user) return res.status(404).json({ error: 'Nutzer nicht gefunden' });
-    if (user.balance < 0) {
-      return res
-        .status(400)
-        .json({ error: 'Guthaben im Minus. Bitte zuerst bei Rischi zahlen.' });
-    }
-    if (user.balance < bet) {
-      return res.status(400).json({ error: 'Nicht genug Guthaben' });
-    }
+    const round = await playPokerRound(userId, amount);
 
-    const win = Math.random() >= 0.6; // 40% Chance auf Gewinn
-    let newBalance = user.balance - bet;
-    if (win) {
-      newBalance += bet * 2;
-      await debitBank(bet);
-    } else {
-      await creditBank(bet);
-    }
+    const stats = await getStats(userId);
 
-    const { error: upErr } = await supabase
-      .from('users')
-      .update({ balance: newBalance })
-      .eq('id', userId);
-    if (upErr) return res.status(500).json({ error: 'Datenbankfehler' });
+    const message = randomMessage(
+      round.result === 'jackpot' ? 'jackpot' : round.result,
+    );
+    const sound =
+      round.result === 'loss'
+        ? 'lose.mp3'
+        : round.result === 'win'
+          ? 'win.mp3'
+          : 'jackpot.mp3';
 
-    res.json({ win, newBalance });
+    const response = {
+      result: round.result,
+      message:
+        `${message} ${round.multiplier > 1 ? `Du hast das ${round.multiplier}-FACHE gewonnen!` : ''}`.trim(),
+      balance: round.balance,
+      multiplier: round.multiplier,
+      sound,
+      stats,
+    };
+
+    const delay = Math.random() * 2000 + 1000; // 1-3s
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
+    res.json(response);
   }),
 );
 

--- a/kiosk-backend/services/pokerService.js
+++ b/kiosk-backend/services/pokerService.js
@@ -1,0 +1,69 @@
+import supabase from '../utils/supabase.js';
+import { creditBank, debitBank } from '../utils/bank.js';
+
+const outcomePool = [
+  ...Array(66).fill(0),
+  ...Array(22).fill(2),
+  ...Array(6).fill(3),
+  ...Array(4).fill(5),
+  ...Array(2).fill(10),
+];
+
+function pickMultiplier() {
+  return outcomePool[Math.floor(Math.random() * outcomePool.length)];
+}
+
+function getResultType(multiplier) {
+  if (multiplier === 0) return 'loss';
+  if (multiplier === 2) return 'win';
+  return 'jackpot';
+}
+
+export async function playPokerRound(userId, amount) {
+  const { data: user, error } = await supabase
+    .from('users')
+    .select('balance')
+    .eq('id', userId)
+    .single();
+
+  if (error || !user) {
+    const err = new Error('Datenbankfehler');
+    err.status = 500;
+    throw err;
+  }
+
+  if (user.balance < amount || user.balance < 0) {
+    const err = new Error('Nicht genug Guthaben');
+    err.status = 400;
+    throw err;
+  }
+
+  const multiplier = pickMultiplier();
+  const result = getResultType(multiplier);
+
+  let newBalance = user.balance - amount;
+  if (multiplier > 0) {
+    newBalance += amount * multiplier;
+    await debitBank(amount * (multiplier - 1));
+  } else {
+    await creditBank(amount);
+  }
+
+  const [{ error: upErr }, { error: insertErr }] = await Promise.all([
+    supabase.from('users').update({ balance: newBalance }).eq('id', userId),
+    supabase.from('poker_rounds').insert({
+      user_id: userId,
+      amount,
+      result,
+      multiplier,
+    }),
+  ]);
+
+  if (upErr || insertErr) {
+    const err = new Error('Datenbankfehler');
+    err.status = 500;
+    throw err;
+  }
+
+  return { result, multiplier, balance: newBalance };
+}

--- a/kiosk-backend/sql/poker_rounds.sql
+++ b/kiosk-backend/sql/poker_rounds.sql
@@ -1,0 +1,8 @@
+CREATE TABLE poker_rounds (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  amount INTEGER NOT NULL,
+  result TEXT NOT NULL CHECK (result IN ('loss', 'win', 'jackpot')),
+  multiplier INTEGER NOT NULL CHECK (multiplier >= 0),
+  created_at TIMESTAMP DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- store poker rounds in new `poker_rounds` table
- add service `playPokerRound` with weighted outcome logic and bank transfers
- expand `/api/poker/play` to return messages, sounds and stats

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6847536649348320a98fe8bc3029df00