### PR TITLE
Implement color choice for Zock Royale

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,10 @@ Weitere Details zum kompletten Ablauf finden sich in [docs/buzzer_flow.md](docs/
 
 ## Zock Royale
 
-Zock Royale ist ein kleines Spaß-Pokerspiel. Über `/api/poker/play` kannst du
-einen Einsatz platzieren. In 35 % der Fälle verdoppelt sich dein Einsatz, in
-5 % gibt es sogar das Vierfache als Jackpot. Verlierst du, landet der Einsatz
-auf dem Konto, das in `BANK_USER_NAME` hinterlegt ist (in der Regel der
-„Haus“-Account). Gewinnt der Spieler, wird ihm der Gewinn aus dem Guthaben des
-Haus-Kontos ausgezahlt. Somit hat das Haus eine Gewinnchance von 60 %. Das
-Ergebnis wird im Nutzerkonto gespeichert. Eine humorvolle Anleitung findest du
-unter [docs/zock_royale_anleitung.md](docs/zock_royale_anleitung.md).
+Zock Royale ist ein kleines Spaß-Pokerspiel. Über `/api/poker/play` platzierst
+du einen Einsatz, wählst Rot oder Schwarz und hoffst auf die richtige Farbe.
+Deckt der Server eine Karte deiner Farbe auf, erhältst du den doppelten Einsatz
+ausgezahlt, andernfalls geht der Betrag an den hinterlegten
+`BANK_USER_NAME`‑Account. Das Ergebnis wird im Nutzerkonto gespeichert. Eine
+humorvolle Anleitung findest du unter
+[docs/zock_royale_anleitung.md](docs/zock_royale_anleitung.md).

--- a/docs/zock_royale_anleitung.md
+++ b/docs/zock_royale_anleitung.md
@@ -1,10 +1,9 @@
 # Zock Royale Anleitung
 
 1. Öffne die Seite `poker.html` und logge dich ein.
-2. Wähle deinen Einsatz, atme tief durch und drücke **Spielen**.
-3. Mit 35 % Chance verdoppelst du dein Geld, bei 5 % gibt es sogar
-   das Vierfache als Jackpot – juhu!
-4. Verlieren tut weh, freut aber den Kiosk. Also lieber nicht gleich
-   Haus und Hof verspielen.
+2. Wähle deinen Einsatz **und** eine Farbe (Rot oder Schwarz).
+3. Drücke **Spielen** – trifft die gezogene Karte deine Farbe,
+   verdoppelt sich dein Einsatz.
+4. Liegt du falsch, wandert der Einsatz in die Kiosk-Kasse.
 
 Viel Spaß und denk dran: Das Haus hat die besseren Karten.

--- a/kiosk-backend/public/poker.html
+++ b/kiosk-backend/public/poker.html
@@ -239,6 +239,22 @@
               10 €
             </button>
           </div>
+          <div id="color-select" class="flex justify-center gap-2 mt-2">
+            <button
+              type="button"
+              data-color="red"
+              class="color-choice bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded"
+            >
+              Rot ♥
+            </button>
+            <button
+              type="button"
+              data-color="black"
+              class="color-choice bg-black hover:bg-gray-800 text-white px-3 py-1 rounded"
+            >
+              Schwarz ♠
+            </button>
+          </div>
           <button
             id="play"
             class="w-full bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded"

--- a/kiosk-backend/public/poker.js
+++ b/kiosk-backend/public/poker.js
@@ -19,13 +19,14 @@ async function getCsrfToken() {
 
 let userBalance = 0;
 
+let selectedColor = null;
+
 const balanceEl = document.getElementById('balance');
 const resultCard = document.getElementById('result-card');
 
-function launchConfetti(jackpot) {
+function launchConfetti() {
   if (typeof confetti === 'function') {
-    const count = jackpot ? 150 : 80;
-    confetti({ particleCount: count, spread: 60, origin: { y: 0.6 } });
+    confetti({ particleCount: 80, spread: 60, origin: { y: 0.6 } });
   }
 }
 
@@ -47,6 +48,18 @@ async function loadUser() {
 async function playPoker() {
   const betInput = document.getElementById('bet');
   const bet = parseFloat(betInput.value.replace(',', '.'));
+  if (!selectedColor) {
+    const resultEl = document.getElementById('result');
+    resultEl.textContent = 'Bitte zuerst eine Farbe wählen';
+    resultCard.classList.remove('result-win', 'result-lose', 'hidden');
+    resultCard.classList.add('result-show', 'result-lose');
+    setTimeout(() => {
+      resultCard.classList.add('hidden');
+      resultCard.classList.remove('result-show', 'result-lose');
+      resultEl.textContent = '';
+    }, 1500);
+    return;
+  }
   if (!bet || bet <= 0) {
     const resultEl = document.getElementById('result');
     resultEl.textContent = 'Ungültiger Einsatz';
@@ -67,7 +80,7 @@ async function playPoker() {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json', 'x-csrf-token': token },
-      body: JSON.stringify({ bet }),
+      body: JSON.stringify({ bet, color: selectedColor }),
     });
     const data = await res.json();
     if (!res.ok) throw new Error(data.error || 'Fehler');
@@ -75,12 +88,8 @@ async function playPoker() {
     balanceEl.textContent = `${userBalance.toFixed(2)} €`;
     balanceEl.classList.add('balance-update');
     const resultEl = document.getElementById('result');
-    const message = data.jackpot
-      ? 'Jackpot! Vierfacher Gewinn!'
-      : data.win
-        ? 'Gewonnen!'
-        : 'Verloren!';
-    resultEl.textContent = message;
+    const message = data.win ? 'Gewonnen!' : 'Verloren!';
+    resultEl.textContent = `${message} (${data.card.symbol})`;
     resultCard.classList.remove('hidden', 'result-win', 'result-lose');
     resultCard.classList.add(
       'result-show',
@@ -88,7 +97,7 @@ async function playPoker() {
     );
     if (data.win) {
       resultEl.classList.add('win-animation');
-      launchConfetti(data.jackpot);
+      launchConfetti();
     } else {
       resultEl.classList.add('lose-animation');
     }
@@ -129,6 +138,15 @@ document.addEventListener('DOMContentLoaded', () => {
       betInput.value = parseFloat(btn.dataset.bet).toFixed(2);
       document
         .querySelectorAll('.quick-bet')
+        .forEach((b) => b.classList.remove('ring-2', 'ring-offset-2'));
+      btn.classList.add('ring-2', 'ring-offset-2');
+    });
+  });
+  document.querySelectorAll('.color-choice').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      selectedColor = btn.dataset.color;
+      document
+        .querySelectorAll('.color-choice')
         .forEach((b) => b.classList.remove('ring-2', 'ring-offset-2'));
       btn.classList.add('ring-2', 'ring-offset-2');
     });

--- a/kiosk-backend/routes/poker.js
+++ b/kiosk-backend/routes/poker.js
@@ -15,8 +15,14 @@ router.post(
   asyncHandler(async (req, res) => {
     const userId = req.user.id;
     const bet = parseFloat(req.body.bet);
+    const color = req.body.color;
     if (!bet || bet <= 0) {
       return res.status(400).json({ error: 'Ungültiger Einsatz' });
+    }
+    if (color !== 'red' && color !== 'black') {
+      return res
+        .status(400)
+        .json({ error: 'Farbe muss rot oder schwarz sein' });
     }
 
     const { data: user, error } = await supabase
@@ -35,17 +41,33 @@ router.post(
       return res.status(400).json({ error: 'Nicht genug Guthaben' });
     }
 
-    const rand = Math.random();
-    let multiplier = 0;
-    let jackpot = false;
-    if (rand < 0.05) {
-      multiplier = 4;
-      jackpot = true;
-    } else if (rand < 0.4) {
-      multiplier = 2;
-    }
+    const suits = [
+      { name: 'hearts', symbol: '♥', color: 'red' },
+      { name: 'diamonds', symbol: '♦', color: 'red' },
+      { name: 'clubs', symbol: '♣', color: 'black' },
+      { name: 'spades', symbol: '♠', color: 'black' },
+    ];
+    const ranks = [
+      'A',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '10',
+      'J',
+      'Q',
+      'K',
+    ];
+    const suit = suits[Math.floor(Math.random() * suits.length)];
+    const rank = ranks[Math.floor(Math.random() * ranks.length)];
 
-    const win = multiplier > 0;
+    const win = suit.color === color;
+    const multiplier = win ? 2 : 0;
+    const cardSymbol = `${rank}${suit.symbol}`;
     let newBalance = user.balance - bet;
     if (win) {
       newBalance += bet * multiplier;
@@ -60,7 +82,11 @@ router.post(
       .eq('id', userId);
     if (upErr) return res.status(500).json({ error: 'Datenbankfehler' });
 
-    res.json({ win, jackpot, newBalance });
+    res.json({
+      win,
+      card: { symbol: cardSymbol, color: suit.color },
+      newBalance,
+    });
   }),
 );
 


### PR DESCRIPTION
## Summary
- allow players to choose red or black before playing Zock Royale
- draw a random card on the server and pay out on a correct color guess
- show the card and highlight the result in the frontend
- update instructions and docs

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6848562512288320bf5828804f70bac2