### PR TITLE
Implement session refresh handling

### DIFF
--- a/kiosk-backend/middleware/auth.js
+++ b/kiosk-backend/middleware/auth.js
@@ -3,7 +3,7 @@ import getUserRole from '../utils/getUserRole.js';
 import asyncHandler from '../utils/asyncHandler.js';
 
 export const requireAuth = asyncHandler(async (req, res, next) => {
-  const user = await getUserFromRequest(req);
+  const user = await getUserFromRequest(req, res);
   if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
   req.user = user;
   next();
@@ -11,7 +11,7 @@ export const requireAuth = asyncHandler(async (req, res, next) => {
 
 export const requireAdmin = asyncHandler(async (req, res, next) => {
   if (!req.user) {
-    const user = await getUserFromRequest(req);
+    const user = await getUserFromRequest(req, res);
     if (!user) return res.status(401).json({ error: 'Nicht eingeloggt' });
     req.user = user;
   }

--- a/kiosk-backend/routes/feed.js
+++ b/kiosk-backend/routes/feed.js
@@ -25,7 +25,7 @@ router.get(
 router.post(
   '/',
   asyncHandler(async (req, res) => {
-    const user = await getUserFromRequest(req);
+    const user = await getUserFromRequest(req, res);
     const { type } = req.body;
 
     const name = user ? (await getUserName(user.id)) || user.email : null;

--- a/kiosk-backend/routes/products.js
+++ b/kiosk-backend/routes/products.js
@@ -9,7 +9,7 @@ const router = express.Router();
 router.get(
   '/',
   asyncHandler(async (req, res) => {
-    const user = await getUserFromRequest(req);
+    const user = await getUserFromRequest(req, res);
     const role = user ? await getUserRole(user.id) : null;
 
     const { products, error } = await listProducts(req.query.sort, role);

--- a/kiosk-backend/utils/authCookies.js
+++ b/kiosk-backend/utils/authCookies.js
@@ -16,10 +16,16 @@ export function getCookieOptions() {
   return options;
 }
 
-export function setAuthCookie(res, token) {
-  res.cookie('sb-access-token', token, getCookieOptions());
+export function setAuthCookies(res, { access_token, refresh_token }) {
+  if (access_token) {
+    res.cookie('sb-access-token', access_token, getCookieOptions());
+  }
+  if (refresh_token) {
+    res.cookie('sb-refresh-token', refresh_token, getCookieOptions());
+  }
 }
 
-export function clearAuthCookie(res) {
+export function clearAuthCookies(res) {
   res.clearCookie('sb-access-token', getCookieOptions());
+  res.clearCookie('sb-refresh-token', getCookieOptions());
 }


### PR DESCRIPTION
## Summary
- add persistent refresh cookie helpers
- automatically refresh session in auth routes and middleware
- persist refreshed tokens when optional user lookup happens

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684b3fcb67948320b18530d05ed8aa69