### PR TITLE
Fix session check timing in frontend

### DIFF
--- a/kiosk-backend/public/dashboard.js
+++ b/kiosk-backend/public/dashboard.js
@@ -22,7 +22,7 @@ async function getCsrfToken() {
   }
 }
 
-async function checkUserAndRole() {
+async function checkUserAndRole(retries = 3) {
   try {
     // Erst prüfen, ob eine gültige Session existiert
     const meRes = await fetch(`${BACKEND_URL}/api/auth/me`, {
@@ -32,6 +32,10 @@ async function checkUserAndRole() {
     const { loggedIn } = await meRes.json();
 
     if (!meRes.ok || !loggedIn) {
+      if (retries > 0) {
+        setTimeout(() => checkUserAndRole(retries - 1), 500);
+        return;
+      }
       window.location.href = 'index.html';
       return;
     }


### PR DESCRIPTION
## Summary
- retry session detection before redirecting to login
- add retry helper to buzzer login check

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_b_684b88a1e5b08320b40ee85751768da3