### PR TITLE
Improve login session handling

### DIFF
--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -26,7 +26,7 @@ if (localStorage.getItem('darkMode') !== 'false') {
   document.documentElement.classList.add('dark');
 }
 
-async function checkUser(retries = 3) {
+async function checkUser(retries = 6) {
   try {
     const res = await fetch(`${BACKEND_URL}/api/user`, {
       credentials: 'include',

--- a/kiosk-backend/public/dashboard.js
+++ b/kiosk-backend/public/dashboard.js
@@ -22,7 +22,7 @@ async function getCsrfToken() {
   }
 }
 
-async function checkUserAndRole(retries = 3) {
+async function checkUserAndRole(retries = 6) {
   try {
     // Erst prüfen, ob eine gültige Session existiert
     const meRes = await fetch(`${BACKEND_URL}/api/auth/me`, {


### PR DESCRIPTION
## Summary
- wait for session after login before redirecting
- retry session validation longer in dashboard and buzzer scripts

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_684b8a55ac10832085767dc8759b8cac