### PR TITLE
Fix early dashboard navigation logout

### DIFF
--- a/kiosk-backend/public/dashboard.html
+++ b/kiosk-backend/public/dashboard.html
@@ -86,7 +86,7 @@
   </div>
   <div class="text-center p-6 sm:p-10 rounded-3xl panel-shadow border-4 border-green-300 dark:border-green-500 glass-effect space-y-6 animate-fade-in">
     <h1 class="text-3xl sm:text-4xl font-bold">🚀 Was willst du tun?</h1>
-    <div class="flex flex-col sm:flex-row gap-6 justify-center items-center mt-6">
+    <div id="nav-buttons" class="flex flex-col sm:flex-row gap-6 justify-center items-center mt-6 opacity-50 pointer-events-none">
       <a href="shop.html" class="bg-green-600 hover:bg-green-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛒 Zum Kiosk</a>
       <a href="buzzer.html" class="bg-yellow-500 hover:bg-yellow-600 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🔔 Buzzern</a>
       <a href="mentos.html" class="bg-purple-600 hover:bg-purple-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🐱 Mentos</a>

--- a/kiosk-backend/public/dashboard.js
+++ b/kiosk-backend/public/dashboard.js
@@ -55,6 +55,9 @@ async function checkUserAndRole(retries = 6) {
     if (user.role === 'admin') {
       document.getElementById('admin-btn')?.classList.remove('hidden');
     }
+    document
+      .getElementById('nav-buttons')
+      ?.classList.remove('opacity-50', 'pointer-events-none');
   } catch (err) {
     if (err.name === 'AbortError') return;
     console.error('Fehler beim Laden des Nutzers', err);


### PR DESCRIPTION
## Summary
- prevent navigation while session loads
- re-enable dashboard buttons once user check succeeds

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684c238ce1788320941eec00befb7b4a