### PR TITLE
Fix non-clickable dashboard buttons

### DIFF
--- a/kiosk-backend/public/admin.html
+++ b/kiosk-backend/public/admin.html
@@ -14,7 +14,7 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <!-- JavaScript-Logik -->
-  <script src="admin.js" defer></script>
+  <script src="/admin.js" defer></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap" rel="stylesheet">
   <link rel="icon" href="/favicon.jpeg" type="image/jpeg">
   <style>

--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -20,7 +20,7 @@
     <script>
       tailwind.config = { darkMode: 'class' };
     </script>
-    <script src="buzzer.js" defer></script>
+    <script src="/buzzer.js" defer></script>
 
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap"

--- a/kiosk-backend/public/dashboard.html
+++ b/kiosk-backend/public/dashboard.html
@@ -13,7 +13,7 @@
   <script>
     tailwind.config = { darkMode: 'class' };
   </script>
-  <script src="dashboard.js" defer></script>
+  <script src="/dashboard.js" defer></script>
 
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap" rel="stylesheet">
   <link rel="icon" href="/favicon.jpeg" type="image/jpeg">

--- a/kiosk-backend/public/shop.html
+++ b/kiosk-backend/public/shop.html
@@ -16,7 +16,7 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <!-- Externe Scripts -->
-  <script src="shop.js" defer></script>
+  <script src="/shop.js" defer></script>
 
   <!-- Fonts und Styles -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- use absolute paths for frontend scripts so they load correctly

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684c288da054832084d5bda01328f78f