### PR TITLE
Add meta descriptions to front-end

### DIFF
--- a/kiosk-backend/public/admin.html
+++ b/kiosk-backend/public/admin.html
@@ -9,6 +9,7 @@
   <meta name="format-detection" content="telephone=no">
   <meta name="theme-color" content="#0f172a">
   <title>Adminbereich – Rischis Kiosk</title>
+  <meta name="description" content="Produkte und Spielrunden verwalten" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { darkMode: 'class' };

--- a/kiosk-backend/public/buzzer.html
+++ b/kiosk-backend/public/buzzer.html
@@ -15,6 +15,7 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="theme-color" content="#0f172a" />
     <title>Buzzer – Rischis Kiosk</title>
+    <meta name="description" content="Multiplayer Musikquiz mit Buzz-Funktion" />
 
     <script src="https://cdn.tailwindcss.com"></script>
     <script>

--- a/kiosk-backend/public/dashboard.html
+++ b/kiosk-backend/public/dashboard.html
@@ -9,6 +9,7 @@
   <meta name="format-detection" content="telephone=no">
   <meta name="theme-color" content="#0f172a">
   <title>Rischis Kiosk – Auswahl</title>
+  <meta name="description" content="Auswahlmenü für Shop, Buzzer und Mentos" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { darkMode: 'class' };

--- a/kiosk-backend/public/index.html
+++ b/kiosk-backend/public/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Rischis Kiosk – Login</title>
+  <meta name="description" content="Login und Registrierung für Rischis Kiosk" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { darkMode: 'class' };

--- a/kiosk-backend/public/mentos.html
+++ b/kiosk-backend/public/mentos.html
@@ -15,6 +15,7 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="theme-color" content="#0f172a" />
     <title>Mentos – Fütterungstracker</title>
+    <meta name="description" content="Fütterungszeiten für Mentos protokollieren" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = { darkMode: 'class' };

--- a/kiosk-backend/public/shop.html
+++ b/kiosk-backend/public/shop.html
@@ -9,6 +9,7 @@
   <meta name="format-detection" content="telephone=no" />
   <meta name="theme-color" content="#0f172a" />
   <title>Rischis Kiosk – Shop</title>
+  <meta name="description" content="Digitale Einkaufsoberfläche des Kiosks" />
 
   <!-- Tailwind & Supabase -->
   <script src="https://cdn.tailwindcss.com"></script>


### PR DESCRIPTION
## Summary
- improve SEO by adding meta description tags to all HTML pages

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684c40e51dcc8320a847d59821e82de3