### PR TITLE
Fix early clicks on dashboard

### DIFF
--- a/kiosk-backend/public/dashboard.html
+++ b/kiosk-backend/public/dashboard.html
@@ -72,6 +72,15 @@
     .dark ::placeholder {
       color: #9ca3af;
     }
+    .loader {
+      display: none;
+      margin-bottom: 1rem;
+      font-weight: bold;
+    }
+    .disabled-link {
+      pointer-events: none;
+      opacity: 0.5;
+    }
   </style>
 </head>
 <body class="flex items-center justify-center min-h-screen text-green-900 relative dark:text-white">
@@ -87,10 +96,11 @@
   </div>
   <div class="text-center p-6 sm:p-10 rounded-3xl panel-shadow border-4 border-green-300 dark:border-green-500 glass-effect space-y-6 animate-fade-in">
     <h1 class="text-3xl sm:text-4xl font-bold">🚀 Was willst du tun?</h1>
+    <div id="loader" class="loader hidden">Loading...</div>
     <div class="flex flex-col sm:flex-row gap-6 justify-center items-center mt-6">
-      <a href="shop.html" class="bg-green-600 hover:bg-green-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛒 Zum Kiosk</a>
-      <a href="buzzer.html" class="bg-yellow-500 hover:bg-yellow-600 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🔔 Buzzern</a>
-      <a href="mentos.html" class="bg-purple-600 hover:bg-purple-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🐱 Mentos</a>
+      <a id="kiosk-btn" href="shop.html" class="bg-green-600 hover:bg-green-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛒 Zum Kiosk</a>
+      <a id="buzzer-btn" href="buzzer.html" class="bg-yellow-500 hover:bg-yellow-600 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🔔 Buzzern</a>
+      <a id="mentos-btn" href="mentos.html" class="bg-purple-600 hover:bg-purple-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🐱 Mentos</a>
       <a id="admin-btn" href="admin.html" class="hidden bg-red-600 hover:bg-red-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛠️ Adminbereich</a>
     </div>
   </div>

--- a/kiosk-backend/public/dashboard.js
+++ b/kiosk-backend/public/dashboard.js
@@ -8,6 +8,10 @@ const BACKEND_URL = window.location.origin;
 const controller = new AbortController();
 window.addEventListener('beforeunload', () => controller.abort());
 
+let currentRole = null;
+const buttons = [];
+let adminButton = null;
+
 async function getCsrfToken() {
   try {
     const res = await fetch(`${BACKEND_URL}/api/csrf-token`, {
@@ -52,9 +56,12 @@ async function checkUserAndRole(retries = 6) {
       return;
     }
 
+    currentRole = user.role;
+    adminButton = document.getElementById('admin-btn');
     if (user.role === 'admin') {
-      document.getElementById('admin-btn')?.classList.remove('hidden');
+      adminButton?.classList.remove('hidden');
     }
+    setupActivation();
   } catch (err) {
     if (err.name === 'AbortError') return;
     console.error('Fehler beim Laden des Nutzers', err);
@@ -71,8 +78,6 @@ if (localStorage.getItem('darkMode') !== 'false') {
   document.documentElement.classList.add('dark');
 }
 
-window.addEventListener('DOMContentLoaded', checkUserAndRole);
-
 async function logout() {
   try {
     const token = await getCsrfToken();
@@ -88,3 +93,57 @@ async function logout() {
     window.location.href = 'index.html';
   }
 }
+
+function setupButtons() {
+  buttons.push(
+    document.getElementById('kiosk-btn'),
+    document.getElementById('buzzer-btn'),
+    document.getElementById('mentos-btn')
+  );
+  adminButton = document.getElementById('admin-btn');
+  if (adminButton) buttons.push(adminButton);
+  buttons.forEach((btn) => {
+    if (!btn) return;
+    btn.classList.add('disabled-link');
+    btn.addEventListener('click', (e) => {
+      if (btn.classList.contains('disabled-link')) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    });
+  });
+}
+
+function disableButtons() {
+  document.getElementById('loader').classList.remove('hidden');
+  buttons.forEach((btn) => btn?.classList.add('disabled-link'));
+}
+
+function enableButtons() {
+  document.getElementById('loader').classList.add('hidden');
+  buttons.forEach((btn) => btn?.classList.remove('disabled-link'));
+}
+
+function setupActivation() {
+  if (currentRole === 'admin') {
+    const observer = new MutationObserver(() => {
+      if (adminButton && adminButton.offsetParent !== null) {
+        observer.disconnect();
+        enableButtons();
+      }
+    });
+    if (adminButton && adminButton.offsetParent !== null) {
+      enableButtons();
+    } else {
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
+  } else {
+    setTimeout(enableButtons, 2000);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  setupButtons();
+  disableButtons();
+  checkUserAndRole();
+});


### PR DESCRIPTION
## Summary
- add loader and button ids in dashboard HTML
- block dashboard button clicks until the UI is ready

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684c4378daac8320af61841fb1b001c0