### PR TITLE
Fix early clicks on dashboard

### DIFF
--- a/kiosk-backend/public/dashboard.html
+++ b/kiosk-backend/public/dashboard.html
@@ -72,6 +72,14 @@
     .dark ::placeholder {
       color: #9ca3af;
     }
+    .loader {
+      margin-bottom: 1rem;
+      font-weight: bold;
+    }
+    .disabled-link {
+      pointer-events: none;
+      opacity: 0.5;
+    }
   </style>
 </head>
 <body class="flex items-center justify-center min-h-screen text-green-900 relative dark:text-white">
@@ -87,11 +95,12 @@
   </div>
   <div class="text-center p-6 sm:p-10 rounded-3xl panel-shadow border-4 border-green-300 dark:border-green-500 glass-effect space-y-6 animate-fade-in">
     <h1 class="text-3xl sm:text-4xl font-bold">🚀 Was willst du tun?</h1>
+    <div id="loader" class="loader">Loading...</div>
     <div class="flex flex-col sm:flex-row gap-6 justify-center items-center mt-6">
-      <a href="shop.html" class="bg-green-600 hover:bg-green-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛒 Zum Kiosk</a>
-      <a href="buzzer.html" class="bg-yellow-500 hover:bg-yellow-600 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🔔 Buzzern</a>
-      <a href="mentos.html" class="bg-purple-600 hover:bg-purple-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🐱 Mentos</a>
-      <a id="admin-btn" href="admin.html" class="hidden bg-red-600 hover:bg-red-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛠️ Adminbereich</a>
+      <a id="kiosk-btn" href="shop.html" class="disabled-link bg-green-600 hover:bg-green-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛒 Zum Kiosk</a>
+      <a id="buzzer-btn" href="buzzer.html" class="disabled-link bg-yellow-500 hover:bg-yellow-600 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🔔 Buzzern</a>
+      <a id="mentos-btn" href="mentos.html" class="disabled-link bg-purple-600 hover:bg-purple-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🐱 Mentos</a>
+      <a id="admin-btn" href="admin.html" class="disabled-link hidden bg-red-600 hover:bg-red-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛠️ Adminbereich</a>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add loader and button ids in dashboard HTML
- block dashboard button clicks until the UI is ready
- ensure loader visible and disable buttons from initial HTML

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684c4378daac8320af61841fb1b001c0