### PR TITLE
Update loader default state

### DIFF
--- a/kiosk-backend/public/dashboard.html
+++ b/kiosk-backend/public/dashboard.html
@@ -73,7 +73,7 @@
       color: #9ca3af;
     }
     .loader {
-      display: none;
+      display: block;
       margin-bottom: 1rem;
       font-weight: bold;
     }
@@ -96,12 +96,12 @@
   </div>
   <div class="text-center p-6 sm:p-10 rounded-3xl panel-shadow border-4 border-green-300 dark:border-green-500 glass-effect space-y-6 animate-fade-in">
     <h1 class="text-3xl sm:text-4xl font-bold">🚀 Was willst du tun?</h1>
-    <div id="loader" class="loader hidden">Loading...</div>
+    <div id="loader" class="loader">Loading...</div>
     <div class="flex flex-col sm:flex-row gap-6 justify-center items-center mt-6">
-      <a id="kiosk-btn" href="shop.html" class="bg-green-600 hover:bg-green-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛒 Zum Kiosk</a>
-      <a id="buzzer-btn" href="buzzer.html" class="bg-yellow-500 hover:bg-yellow-600 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🔔 Buzzern</a>
-      <a id="mentos-btn" href="mentos.html" class="bg-purple-600 hover:bg-purple-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🐱 Mentos</a>
-      <a id="admin-btn" href="admin.html" class="hidden bg-red-600 hover:bg-red-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛠️ Adminbereich</a>
+      <a id="kiosk-btn" href="shop.html" class="disabled-link bg-green-600 hover:bg-green-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛒 Zum Kiosk</a>
+      <a id="buzzer-btn" href="buzzer.html" class="disabled-link bg-yellow-500 hover:bg-yellow-600 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🔔 Buzzern</a>
+      <a id="mentos-btn" href="mentos.html" class="disabled-link bg-purple-600 hover:bg-purple-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🐱 Mentos</a>
+      <a id="admin-btn" href="admin.html" class="hidden disabled-link bg-red-600 hover:bg-red-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛠️ Adminbereich</a>
     </div>
   </div>
 </body>

--- a/kiosk-backend/public/dashboard.js
+++ b/kiosk-backend/public/dashboard.js
@@ -104,7 +104,6 @@ function setupButtons() {
   if (adminButton) buttons.push(adminButton);
   buttons.forEach((btn) => {
     if (!btn) return;
-    btn.classList.add('disabled-link');
     btn.addEventListener('click', (e) => {
       if (btn.classList.contains('disabled-link')) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- make loader visible by default on dashboard page
- mark dashboard buttons as disabled in HTML
- simplify button setup in `dashboard.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684c4899794083208057b71d6a3bea2d