### PR TITLE
Fix repeated welcome message

### DIFF
--- a/kiosk-backend/public/dashboard.js
+++ b/kiosk-backend/public/dashboard.js
@@ -22,7 +22,7 @@ async function getCsrfToken() {
   }
 }
 
-let welcomeShown = false;
+let overlayShown = false;
 let overlayText;
 
 async function checkUserAndRole(retries = 6) {
@@ -43,9 +43,14 @@ async function checkUserAndRole(retries = 6) {
       return;
     }
 
-    if (!welcomeShown) {
-      welcomeShown = true;
-      showWelcome();
+    if (!overlayShown) {
+      overlayShown = true;
+      if (sessionStorage.getItem('firstLogin') === 'true') {
+        sessionStorage.setItem('firstLogin', 'false');
+        showWelcome();
+      } else {
+        showLoading();
+      }
     }
 
     // Danach Benutzerdaten laden
@@ -95,6 +100,7 @@ async function logout() {
   } catch (err) {
     console.error('Fehler beim Logout', err);
   } finally {
+    sessionStorage.removeItem('firstLogin');
     window.location.href = 'index.html';
   }
 }
@@ -134,6 +140,27 @@ function showWelcome() {
       once: true,
     });
   }, 2000);
+}
+
+function showLoading() {
+  const overlay = document.createElement('div');
+  overlay.id = 'welcome-overlay';
+  overlay.className =
+    'fixed inset-0 flex items-center justify-center z-50 text-2xl font-bold bg-white/90 dark:bg-gray-800/90';
+  overlay.style.opacity = '1';
+
+  const text = document.createElement('div');
+  text.textContent = 'Loading...';
+  overlay.appendChild(text);
+
+  document.body.appendChild(overlay);
+
+  setTimeout(() => {
+    overlay.style.opacity = '0';
+    overlay.addEventListener('transitionend', () => overlay.remove(), {
+      once: true,
+    });
+  }, 1000);
 }
 
 function updateWelcomeName(name) {

--- a/kiosk-backend/public/index.html
+++ b/kiosk-backend/public/index.html
@@ -143,6 +143,7 @@
       const data = await res.json();
       if (res.ok) {
         showMessage("Login erfolgreich! Weiterleitung...", true);
+        sessionStorage.setItem('firstLogin', 'true');
         setTimeout(() => window.location.href = 'dashboard.html', 1000);
       } else {
         showMessage("Login fehlgeschlagen: " + (data.error || ''));

--- a/kiosk-backend/public/index.js
+++ b/kiosk-backend/public/index.js
@@ -69,6 +69,7 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
     if (!res.ok) throw new Error(result.error || 'Login fehlgeschlagen');
 
     showMessage('Login erfolgreich! Weiterleitung...', true);
+    sessionStorage.setItem('firstLogin', 'true');
 
     const waitForSession = async (retries = 10) => {
       for (let i = 0; i < retries; i++) {


### PR DESCRIPTION
## Summary
- keep track of whether dashboard was opened after login
- show quick loading overlay when revisiting the dashboard
- persist login state in `sessionStorage`

## Testing
- `npm run lint`
- `npx prettier --write public/dashboard.js public/index.js public/index.html` *(fails: changed entire html, so reverted)*

------
https://chatgpt.com/codex/tasks/task_b_684c582f66b48320b8acbef2ad9ec5e0