### PR TITLE
Auto-end previous KOLO on new start

### DIFF
--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -299,6 +299,22 @@ router.post(
 
     if (!round) return res.status(400).json({ error: 'Keine aktive Runde' });
 
+    // Deactivate previous KOLO if it is still marked as active
+    const { data: lastKolo } = await supabase
+      .from('kolos')
+      .select('id, active')
+      .eq('round_id', round.id)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (lastKolo?.active) {
+      await supabase
+        .from('kolos')
+        .update({ active: false })
+        .eq('id', lastKolo.id);
+    }
+
     const { data, error } = await supabase
       .from('kolos')
       .insert({ id: randomUUID(), round_id: round.id, active: true })


### PR DESCRIPTION
## Summary
- automatically deactivate the last KOLO when starting a new one

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684c5b0e284c832099b79684ceb9e0c3