### PR TITLE
Fix KOLO info refresh

### DIFF
--- a/kiosk-backend/public/buzzer.js
+++ b/kiosk-backend/public/buzzer.js
@@ -205,6 +205,7 @@ async function init() {
   evt.addEventListener('unlock', () => {
     document.getElementById('buzz-btn').disabled = false;
     document.getElementById('skip-btn').disabled = false;
+    loadKolo();
   });
   evt.addEventListener('lock', () => {
     document.getElementById('buzz-btn').disabled = true;


### PR DESCRIPTION
## Summary
- refresh KOLO status when receiving `unlock` SSE event

## Testing
- `npm run lint`
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_b_684c739a91748320b9d87bfc22c8f965