### PR TITLE
Deactivate round KOLOs on round end

### DIFF
--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -225,6 +225,12 @@ router.post(
       }
     }
 
+    // Mark all KOLOs of this round as inactive
+    await supabase
+      .from('kolos')
+      .update({ active: false })
+      .eq('round_id', round.id);
+
     res.json({ ended: true });
   }),
 );


### PR DESCRIPTION
## Summary
- set all KOLOs of an ended round to inactive

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684c76abd84083208294a61c41d3f6e7