### PR TITLE
Fix KOLO deactivation on round end

### DIFF
--- a/kiosk-backend/routes/buzzer.js
+++ b/kiosk-backend/routes/buzzer.js
@@ -225,11 +225,10 @@ router.post(
       }
     }
 
-    // Mark all KOLOs of this round as inactive
+    // Mark all KOLOs as inactive
     await supabase
       .from('kolos')
-      .update({ active: false })
-      .eq('round_id', round.id);
+      .update({ active: false });
 
     res.json({ ended: true });
   }),


### PR DESCRIPTION
## Summary
- mark all KOLOs as inactive when ending a round

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684c7c915dd883208e36f5c29defcaf0